### PR TITLE
SRE-2249 CDKTF Diff Standalone Action

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright snapsheet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# CDKTF Synth
+
+Execute cdktf diff, parse STDOUT/STDERR output, and return outputs based on the outcomes.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,81 @@
 # CDKTF Synth
 
-Execute cdktf diff, parse STDOUT/STDERR output, and return outputs based on the outcomes.
+Execute `cdktf diff`, parse STDOUT/STDERR output, and return outputs based on the outcomes.
+
+## Usage
+
+```yaml
+jobs:
+  run_diffs:
+    name: Run diffs
+    strategy:
+      fail-fast: false
+      matrix: 
+        name: ["project-stack", "qa-stack", "prod-stack"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: "${{ matrix.name }}: Diff for my-feature-branch"
+        uses: snapsheet/cdktf-diff@TEST_SRE-2249-cdktf-diff-standalone-action
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          job_name: Run diffs (${{ matrix.name }}) # Needs to match the name of the job as it will show in the run, including interpolations.
+          output_filename: outputs.json
+          ref: my-feature-branch
+          stack: ${{ matrix.name }}
+          terraform_version: ${{ inputs.terraform_version }}
+          working_directory: ./cdktf
+```
+
+## Inputs
+
+| Input | Required? | Default | Description |
+| ----- | --------- | ------- | ----------- |
+| `github_token` | `true` | | The GitHub token used to create an authenticated client. For most cases, set this to `${{ secrets.GITHUB_TOKEN }}` |
+| `job_name` | `true` |  | `jobs.<job-id>.name` of this workflow job. This is needed to get the job ID via query. This needs to match the name of the job as it will show in the run, including interpolations. |
+| `output_filename` | `true` | `"./"` | Working directory path that contains your cdktf code. |
+| `ref` | `true` |  | The ref (branch or SHA) to use with the diff. |
+| `stack` | `true` |  | Full name of the CDKTF stack to diff. |
+| `stub_output_file` | `false` | | When present, no Terraform will execute. The output of this action will be substituted with the output contained in this file. This is useful for cases when you want to test but don't have authentication set up. |
+| `terraform_version` | `false` | `1.8.0` | The version of Terraform to use |
+| `working_directory` | `false` | `"./"` | Working directory path that contains your cdktf code. |
+
+## Outputs
+
+| Output | Description |
+| ------ | ----------- |
+| `html_url` | Direct link to this job, which shows the full execution output. |
+| `job_id` | ID of this job. |
+| `result_code` | Similar to [-detailed-exitcode](https://developer.hashicorp.com/terraform/cli/commands/plan#detailed-exitcode) behavior for Terraform, not yet supported by CDKTF. `0` = Succeeded with empty diff (no changes), `1` = Error, `2` = Succeeded with non-empty diff (changes present) |
+| `stack` | Full name of the CDKTF stack used for the diff. |
+| `summary` | Single string of output to summarize the results (ie, `No changes. Your infrastructure matches the configuration.`) |
+
+## Testing
+
+You can test how this process parses output by using `inputs.stub_output_file`. When present, Terraform processes will not be ran, and instead the given file will be used to simulate the output of running `cdktf diff`. You can generate an example file by running the following:
+```
+CI=1 cdktf diff > my-example-file.txt
+```
+
+Assuming this file is in the root path of your repository directory, you reference it in the config:
+```yaml
+jobs:
+  run_diffs:
+    name: Run diffs
+    strategy:
+      fail-fast: false
+      matrix: 
+        name: ["project-stack", "qa-stack", "prod-stack"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: "${{ matrix.name }}: Diff for my-feature-branch"
+        uses: snapsheet/cdktf-diff@TEST_SRE-2249-cdktf-diff-standalone-action
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          job_name: Run diffs (${{ matrix.name }})
+          output_filename: outputs.json
+          ref: my-feature-branch
+          stack: ${{ matrix.name }}
+          stub_output_file: my-example-file.txt # <-- LIKE THIS
+          terraform_version: ${{ inputs.terraform_version }}
+          working_directory: ./cdktf
+```

--- a/action.yml
+++ b/action.yml
@@ -19,8 +19,6 @@ inputs:
   output_filename:
     description: Name of the file this jobs outputs will be saved into.
     required: true
-  testing_file_path:
-    description: File only used for testing purposes; not meant to be an actual input.
 outputs:
   result_code:
     description: Similar to exitcode behavior for Terraform, not yet supported by CDKTF.  0 = Succeeded with empty diff (no changes), 1 = Error, 2 = Succeeded with non-empty diff (changes present)
@@ -81,11 +79,7 @@ runs:
 
         # show output in CLI/GitHub and also send to file for later parsing
         DIFF_FILE_PATH="${TMPDIR}cdktf-diff.txt"
-        ### CI=1 npx cdktf diff ${{ inputs.stack }} | tee $DIFF_FILE_PATH
-
-        ### NOT AN ACTUAL USE CASE; ONLY FOR TESTING ###
-        ### Simulate console output at a specific rate to STDOUT, while also being saved to $DIFF_FILE_PATH
-        cat ${{ inputs.testing_file_path }} | perl -pe 'select undef,undef,undef,.05' | tee $DIFF_FILE_PATH
+        CI=1 npx cdktf diff ${{ inputs.stack }} | tee $DIFF_FILE_PATH
 
         # If planning failed due to an error, set the outputs and return.
         if cat $DIFF_FILE_PATH | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | grep "Planning failed. Terraform encountered an error while generating this plan." > /dev/null ; then

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,128 @@
+name: cdktf-diff
+description: Execute cdktf diff, parse STDOUT/STDERR output, and return outputs based on the outcomes.
+inputs:
+  ref:
+    description: Branch/Commit/Tag to use
+    type: string
+  stack:
+    description: Full name of the CDKTF stack to diff.
+    type: string
+  job_name:
+    description: jobs.<job-id>.name of this workflow job. This is needed to get the job ID via query.
+    required: true
+  terraform_version:
+    default: 1.8.0
+    description: The version of Terraform to use
+  working_directory:
+    default: ./
+    description: Working directory path that contains your cdktf code.
+  output_filename:
+    description: Name of the file this jobs outputs will be saved into.
+    required: true
+  testing_file_path:
+    description: File only used for testing purposes; not meant to be an actual input.
+outputs:
+  result_code:
+    description: Similar to exitcode behavior for Terraform, not yet supported by CDKTF.  0 = Succeeded with empty diff (no changes), 1 = Error, 2 = Succeeded with non-empty diff (changes present)
+    value: ${{ steps.diff.outputs.result_code }}
+  summary:
+    description: Single string of output to summarize the results.
+    value: ${{ steps.diff.outputs.summary }}
+  html_url:
+    description: Direct link to this job, which shows the full execution output.
+    value: ${{ steps.jobid_action.outputs.html_url }}
+  stack:
+    description: Full name of the CDKTF stack used for the diff.
+    value: ${{ inputs.stack }}
+  job_id:
+    description: ID of this job
+    value: ${{ steps.jobid_action.outputs.job_id }}
+runs:
+  using: composite
+  steps:
+    - id: jobid_action
+      uses: Tiryoh/gha-jobid-action@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        job_name: ${{ inputs.job_name }}
+
+    - uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: ${{ inputs.terraform_version }}
+
+    - uses: actions/checkout@v4
+      id: checkout
+      with:
+        fetch-depth: 0
+        ref: ${{ inputs.ref }}
+
+    - name: Load Configuration
+      id: configurations
+      shell: bash
+      run: |
+        cd ${{ inputs.working_directory }}
+        echo "node_version=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ steps.configurations.outputs.node_version }}
+
+    - name: Install Node Dependencies
+      shell: bash
+      run: |
+        cd ${{ inputs.working_directory }}
+        npm ci
+
+    - name: Run Diff
+      id: diff
+      shell: bash
+      run: |
+        cd ${{ inputs.working_directory }}
+
+        # show output in CLI/GitHub and also send to file for later parsing
+        DIFF_FILE_PATH="${TMPDIR}cdktf-diff.txt"
+        ### CI=1 npx cdktf diff ${{ inputs.stack }} | tee $DIFF_FILE_PATH
+
+        ### NOT AN ACTUAL USE CASE; ONLY FOR TESTING ###
+        ### Simulate console output at a specific rate to STDOUT, while also being saved to $DIFF_FILE_PATH
+        cat ${{ inputs.testing_file_path }} | perl -pe 'select undef,undef,undef,.05' | tee $DIFF_FILE_PATH
+
+        # If planning failed due to an error, set the outputs and return.
+        if cat $DIFF_FILE_PATH | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | grep "Planning failed. Terraform encountered an error while generating this plan." > /dev/null ; then
+          echo "result_code=1" >> $GITHUB_OUTPUT
+          SUMMARY=$(cat $DIFF_FILE_PATH | grep "Error: " | xargs | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g")
+          echo "summary=$SUMMARY" >> $GITHUB_OUTPUT
+          exit 0 # return code zero so we don't break the rest of the workflow
+        fi        
+
+        # If there are no changes, set the outputs and return.
+        if cat $DIFF_FILE_PATH | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | grep "No changes. Your infrastructure matches the configuration." > /dev/null ; then
+          SUMMARY="No changes. Your infrastructure matches the configuration."
+          echo "result_code=0" >> $GITHUB_OUTPUT
+          echo "summary=$SUMMARY" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        # If there is a plan, set the outputs and return.
+        if cat $DIFF_FILE_PATH | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | grep "Plan:" > /dev/null ; then
+          echo "result_code=2" >> $GITHUB_OUTPUT
+          SUMMARY=$(cat $DIFF_FILE_PATH | grep "Plan:" | xargs | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g")
+          echo "summary=$SUMMARY" >> $GITHUB_OUTPUT
+          exit 0 # return code zero so we don't break the rest of the workflow
+        fi
+
+        echo "Error: Could not determine if diff ran successfully."
+        echo "result_code=1"
+        exit 1
+
+    - name: Dump Outputs to File
+      shell: bash
+      run: |
+        TOTAL_OUTPUTS='{"result_code":${{ steps.diff.outputs.result_code }},"summary":"${{ steps.diff.outputs.summary }}","html_url":"${{ steps.jobid_action.outputs.html_url }}","stack":"${{ inputs.stack }}","job_id":"${{ steps.jobid_action.outputs.job_id }}","node_version":"${{ steps.configurations.outputs.node_version }}","terraform_version":"${{ inputs.terraform_version }}"}'
+        echo $TOTAL_OUTPUTS > ${{ inputs.working_directory }}/${{ inputs.output_filename }}
+
+    - uses: actions/upload-artifact@v4
+      name: Save Outputs
+      with:
+        name: ${{ steps.jobid_action.outputs.job_id }}
+        path: ${{ inputs.working_directory }}/${{ inputs.output_filename }}

--- a/action.yml
+++ b/action.yml
@@ -2,45 +2,44 @@ name: cdktf-diff
 description: Execute cdktf diff, parse STDOUT/STDERR output, and return outputs based on the outcomes.
 inputs:
   github_token:
-    required: true
     description: GITHUB_TOKEN to use GitHub API. Simply specify secrets.GITHUB_TOKEN.
-  ref:
-    description: Branch/Commit/Tag to use
-    type: string
-  stack:
-    description: Full name of the CDKTF stack to diff.
-    type: string
+    required: true
   job_name:
     description: jobs.<job-id>.name of this workflow job. This is needed to get the job ID via query.
     required: true
+  output_filename:
+    description: Name of the file this jobs outputs will be saved into.
+    required: true
+  ref:
+    description: The ref (branch or sha) to use with the diff.
+    required: true
+  stack:
+    description: Full name of the CDKTF stack to diff.
+    required: true
+  stub_output_file:
+    description: When present, no Terraform will execute. The output of this action will be substituted with the output contained in this file. This is useful for cases when you want to test but don't have authentication set up.
   terraform_version:
     default: 1.8.0
     description: The version of Terraform to use
   working_directory:
     default: ./
     description: Working directory path that contains your cdktf code.
-  output_filename:
-    description: Name of the file this jobs outputs will be saved into.
-    required: true
-  stub_output_file:
-    description: When present, no Terraform will execute. The output of this action will be substituted with the output contained in this file. This is useful for cases when you want to test but don't have authentication set up.
-    required: false
 outputs:
-  result_code:
-    description: Similar to exitcode behavior for Terraform, not yet supported by CDKTF.  0 = Succeeded with empty diff (no changes), 1 = Error, 2 = Succeeded with non-empty diff (changes present)
-    value: ${{ steps.diff.outputs.result_code }}
-  summary:
-    description: Single string of output to summarize the results.
-    value: ${{ steps.diff.outputs.summary }}
   html_url:
     description: Direct link to this job, which shows the full execution output.
     value: ${{ steps.jobid_action.outputs.html_url }}
-  stack:
-    description: Full name of the CDKTF stack used for the diff.
-    value: ${{ inputs.stack }}
   job_id:
     description: ID of this job
     value: ${{ steps.jobid_action.outputs.job_id }}
+  result_code:
+    description: Similar to exitcode behavior for Terraform, not yet supported by CDKTF.  0 = Succeeded with empty diff (no changes), 1 = Error, 2 = Succeeded with non-empty diff (changes present)
+    value: ${{ steps.diff.outputs.result_code }}
+  stack:
+    description: Full name of the CDKTF stack used for the diff.
+    value: ${{ inputs.stack }}
+  summary:
+    description: Single string of output to summarize the results.
+    value: ${{ steps.diff.outputs.summary }}
 runs:
   using: composite
   steps:

--- a/action.yml
+++ b/action.yml
@@ -94,10 +94,6 @@ runs:
         DIFF_FILE_PATH="${TMPDIR}cdktf-diff.txt"
         eval $DIFF_COMMAND | tee $DIFF_FILE_PATH
 
-        ### NOT AN ACTUAL USE CASE; ONLY FOR TESTING ###
-        ### Simulate console output at a specific rate to STDOUT, while also being saved to $DIFF_FILE_PATH
-         | tee $DIFF_FILE_PATH
-
         # If planning failed due to an error, set the outputs and return.
         if cat $DIFF_FILE_PATH | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | grep "Planning failed. Terraform encountered an error while generating this plan." > /dev/null ; then
           echo "result_code=1" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ runs:
         # If stub_output_file is present, set the execution command to output this file instead of running diff.
         # Assignment uses single quotes explicitly to prevent possible code injection.
         if [ -f "${{ inputs.stub_output_file }}" ]; then
-          DIFF_COMMAND='cat ${{ inputs.stub_output_file }} | perl -pe \'select undef,undef,undef,.05\''
+          DIFF_COMMAND='cat ${{ inputs.stub_output_file }} | perl -pe "select undef,undef,undef,.05"'
         else
           DIFF_COMMAND='CI=1 npx cdktf diff ${{ inputs.stack }}'
         fi

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
   output_filename:
     description: Name of the file this jobs outputs will be saved into.
     required: true
+  stub_output_file:
+    description: When present, no Terraform will execute. The output of this action will be substituted with the output contained in this file. This is useful for cases when you want to test but don't have authentication set up.
+    required: false
 outputs:
   result_code:
     description: Similar to exitcode behavior for Terraform, not yet supported by CDKTF.  0 = Succeeded with empty diff (no changes), 1 = Error, 2 = Succeeded with non-empty diff (changes present)
@@ -80,9 +83,21 @@ runs:
       run: |
         cd ${{ inputs.working_directory }}
 
+        # If stub_output_file is present, set the execution command to output this file instead of running diff.
+        # Assignment uses single quotes explicitly to prevent possible code injection.
+        if [ -f "${{ inputs.stub_output_file }}" ]; then
+          DIFF_COMMAND='cat ${{ inputs.stub_output_file }} | perl -pe \'select undef,undef,undef,.05\''
+        else
+          DIFF_COMMAND='CI=1 npx cdktf diff ${{ inputs.stack }}'
+        fi
+
         # show output in CLI/GitHub and also send to file for later parsing
         DIFF_FILE_PATH="${TMPDIR}cdktf-diff.txt"
-        CI=1 npx cdktf diff ${{ inputs.stack }} | tee $DIFF_FILE_PATH
+        eval $DIFF_COMMAND | tee $DIFF_FILE_PATH
+
+        ### NOT AN ACTUAL USE CASE; ONLY FOR TESTING ###
+        ### Simulate console output at a specific rate to STDOUT, while also being saved to $DIFF_FILE_PATH
+         | tee $DIFF_FILE_PATH
 
         # If planning failed due to an error, set the outputs and return.
         if cat $DIFF_FILE_PATH | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | grep "Planning failed. Terraform encountered an error while generating this plan." > /dev/null ; then

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
 name: cdktf-diff
 description: Execute cdktf diff, parse STDOUT/STDERR output, and return outputs based on the outcomes.
 inputs:
+  github_token:
+    required: true
+    description: GITHUB_TOKEN to use GitHub API. Simply specify secrets.GITHUB_TOKEN.
   ref:
     description: Branch/Commit/Tag to use
     type: string
@@ -41,7 +44,7 @@ runs:
     - id: jobid_action
       uses: Tiryoh/gha-jobid-action@v1
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ inputs.GITHUB_TOKEN }}
         job_name: ${{ inputs.job_name }}
 
     - uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
## What

This introduces the initial functionality for minimum scope and features to show a diff, return a summary, and a code that tells if it was successful or not.

## Why

This enables us the ability to encapsulate the features of `cdktf diff` we primarily use, and attach it to a workflow pipeline.

## How

* Use the Tiryoh/gha-jobid-action to get the Job ID of the current job (the one defined in this composite action)
* Use hashicorp/setup-terraform to setup terraform in the current job
* Read the `.nvmrc` from the working path and set up Node with that version
* Run `npm ci` to install dependencies needed to run cdktf
* Run `CI=1 npx cdktf diff ${{ inputs.stack }}` to check if a plan is pending
  * Use the `tee` command to show STDOUT/STDERR at runtime while also piping it to a file for later parsing.
  * If planning failed due to an error, set the outputs and return exit code 0
  * If there are no changes, set the outputs and return exit code 0.
  * If there is a plan, set the outputs and return exit code 0.
  * If none of the previous cases were found, exit code 1 with an error that results were inconclusive.
* If `inputs.output_filename` is present, save the output to a file and then to an Artifact so it can be retrieved by another process.

## Usage

Here is an example of how the action can be called by steps in a job:

```yaml
jobs:
  diffs_for_ref:
    name: Diffs for Ref
    strategy:
      fail-fast: false
      matrix: 
        name: ["project-stack", "qa-stack", "prod-stack"]
    runs-on: ubuntu-latest
    steps:
      - name: "${{ matrix.name }}: Diff for ${{ inputs.ref }}"
        uses: snapsheet/cdktf-diff@SRE-2249-cdktf-diff-standalone-action
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          job_name: Diffs for Ref (${{ matrix.name }})
          output_filename: outputs.json
          ref: ${{ inputs.ref }}
          stack: ${{ matrix.name }}
          terraform_version: ${{ inputs.terraform_version }}
          working_directory: ./cdktf
```

## Testing

Try to use the above in a workflow by using `uses: snapsheet/cdktf-diff@SRE-2249-cdktf-diff-standalone-action` in the job steps, and fill out the options based on the README.md updates included in this PR.

Use the `stub_output_file` option to simulate the output of no-changes/plan/error output from cdktf and confirm it acts as expected.