### PR TITLE
Increase per-page count to max for workflows with many jobs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,7 @@ runs:
       with:
         github_token: ${{ inputs.GITHUB_TOKEN }}
         job_name: ${{ inputs.job_name }}
+        per_page: 100
 
     - uses: hashicorp/setup-terraform@v3
       with:


### PR DESCRIPTION
# Why

This action uses [Tiryoh/gha-jobid-action](https://github.com/Tiryoh/gha-jobid-action) to fetch the job ID of the job-instance currently running. When running this for projects with a large set of parallel jobs (more than 30), we see an error:
> parse error, job_id is null and total_count is 40. 'job_name' or 'per_page' might be wrong.

# What

Enable this action to be included in workflows with a large number of parallel jobs (max 100).

# How

Add the [`per_page` input](https://github.com/Tiryoh/gha-jobid-action?tab=readme-ov-file#per_page) and set it to the maximum (`100`).