### PR TITLE
Skip Synth During Diff

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -105,10 +105,10 @@ runs:
 
         # If skip_synth is set to true, add --skip-synth to the command options.
         if [ "${{ inputs.skip_synth }}" == "true" ]; then
-          DIFF_COMMAND= "$DIFF_COMMAND --skip-synth"
+          DIFF_COMMAND="$DIFF_COMMAND --skip-synth"
         fi
 
-        DIFF_COMMAND= "$DIFF_COMMAND ${{ inputs.stack }}"
+        DIFF_COMMAND="$DIFF_COMMAND ${{ inputs.stack }}"
 
         # show output in CLI/GitHub and also send to file for later parsing
         DIFF_FILE_PATH="${TMPDIR}cdktf-diff.txt"

--- a/action.yml
+++ b/action.yml
@@ -110,6 +110,12 @@ runs:
 
         DIFF_COMMAND="$DIFF_COMMAND ${{ inputs.stack }}"
 
+        echo "PWD"
+        ls -lah ./
+
+        echo "CDKTF DIR"
+        ls -lah ./cdktf/
+
         # show output in CLI/GitHub and also send to file for later parsing
         DIFF_FILE_PATH="${TMPDIR}cdktf-diff.txt"
         eval $DIFF_COMMAND | tee $DIFF_FILE_PATH

--- a/action.yml
+++ b/action.yml
@@ -111,10 +111,10 @@ runs:
         DIFF_COMMAND="$DIFF_COMMAND ${{ inputs.stack }}"
 
         echo "PWD"
-        ls -lah ./
+        ls -lah ${{ inputs.working_directory }}
 
         echo "CDKTF DIR"
-        ls -lah ./cdktf/
+        ls -lah ${{ inputs.working_directory }}/cdktf
 
         # show output in CLI/GitHub and also send to file for later parsing
         DIFF_FILE_PATH="${TMPDIR}cdktf-diff.txt"

--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
       uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifact_name }}
-        path: ${{ inputs.working_directory }}
+        path: ${{ inputs.working_directory }}/someplace
 
     - name: Run Diff
       id: diff
@@ -111,10 +111,7 @@ runs:
         DIFF_COMMAND="$DIFF_COMMAND ${{ inputs.stack }}"
 
         echo "PWD"
-        ls -lah ${{ inputs.working_directory }}
-
-        echo "CDKTF DIR"
-        ls -lah ${{ inputs.working_directory }}/cdktf
+        ls -lah
 
         # show output in CLI/GitHub and also send to file for later parsing
         DIFF_FILE_PATH="${TMPDIR}cdktf-diff.txt"

--- a/action.yml
+++ b/action.yml
@@ -104,7 +104,7 @@ runs:
         fi
 
         # If skip_synth is set to true, add --skip-synth to the command options.
-        if [ -f "${{ inputs.skip_synth }}" == "true" ]; then
+        if [ "${{ inputs.skip_synth }}" == "true" ]; then
           DIFF_COMMAND= "$DIFF_COMMAND --skip-synth"
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
       uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifact_name }}
-        path: ${{ inputs.working_directory }}/someplace
+        path: ${{ inputs.working_directory }}/cdktf.out
 
     - name: Run Diff
       id: diff
@@ -109,9 +109,6 @@ runs:
         fi
 
         DIFF_COMMAND="$DIFF_COMMAND ${{ inputs.stack }}"
-
-        echo "SOMEPLACE"
-        ls -lah someplace/
 
         # show output in CLI/GitHub and also send to file for later parsing
         DIFF_FILE_PATH="${TMPDIR}cdktf-diff.txt"

--- a/action.yml
+++ b/action.yml
@@ -110,8 +110,8 @@ runs:
 
         DIFF_COMMAND="$DIFF_COMMAND ${{ inputs.stack }}"
 
-        echo "PWD"
-        ls -lah
+        echo "SOMEPLACE"
+        ls -lah someplace/
 
         # show output in CLI/GitHub and also send to file for later parsing
         DIFF_FILE_PATH="${TMPDIR}cdktf-diff.txt"

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,11 @@ inputs:
   working_directory:
     default: ./
     description: Working directory path that contains your cdktf code.
+  skip_synth:
+    default: false
+    description: Skip synthesis of the application, assume the synthesized Terraform code is already present and up to date
+  artifact_name:
+    description: When given, attempt to download the given artifact contents into this working directory.
 outputs:
   html_url:
     description: Direct link to this job, which shows the full execution output.
@@ -77,6 +82,13 @@ runs:
         cd ${{ inputs.working_directory }}
         npm ci
 
+    - name: Download Artifact Files
+      if: ${{ inputs.artifact_name }}
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ inputs.working_directory }}
+
     - name: Run Diff
       id: diff
       shell: bash
@@ -88,8 +100,15 @@ runs:
         if [ -f "${{ inputs.stub_output_file }}" ]; then
           DIFF_COMMAND='cat ${{ inputs.stub_output_file }} | perl -pe "select undef,undef,undef,.05"'
         else
-          DIFF_COMMAND='CI=1 npx cdktf diff ${{ inputs.stack }}'
+          DIFF_COMMAND='CI=1 npx cdktf diff'
         fi
+
+        # If skip_synth is set to true, add --skip-synth to the command options.
+        if [ -f "${{ inputs.skip_synth }}" == "true" ]; then
+          DIFF_COMMAND= "$DIFF_COMMAND --skip-synth"
+        fi
+
+        DIFF_COMMAND= "$DIFF_COMMAND ${{ inputs.stack }}"
 
         # show output in CLI/GitHub and also send to file for later parsing
         DIFF_FILE_PATH="${TMPDIR}cdktf-diff.txt"


### PR DESCRIPTION
## What

This introduces the option to skip synth when running a diff.

## Why

If a previous synth has already been ran, there is no need to do a synth again. We can reuse the files generated and save time consuming operations.

## How

When `artifact_name` is present, download the artifact and use in the current working path.

When `skip_synth` is present, skip synthesis.

## Testing

Update existing references to point to this branch.

```yaml
- name: "${{ matrix.name }}: Diff for ${{ inputs.ref }}"
  uses: snapsheet/cdktf-diff@SRE-2505-skip-synth-during-diff
  env:
    TF_CLI_ARGS_plan: "-lock-timeout=30s"
  with:
    github_token: ${{ secrets.GITHUB_TOKEN }}
    job_name: Diffs for Ref (${{ matrix.name }})
    output_filename: outputs.json
    ref: ${{ inputs.ref }}
    stack: ${{ matrix.name }}
    terraform_version: ${{ inputs.terraform_version }}
    working_directory: ./cdktf
```

Run a test confirming that it works as expected without any additional options.

Update the configuration to use `artifact_name` and `skip_synth`.

```yaml
- name: "${{ matrix.name }}: Diff for ${{ inputs.ref }}"
  uses: snapsheet/cdktf-diff@SRE-2505-skip-synth-during-diff
  env:
    TF_CLI_ARGS_plan: "-lock-timeout=30s"
  with:
    artifact_name: ${{ needs.ref_setup.outputs.job_id }}
    github_token: ${{ secrets.GITHUB_TOKEN }}
    job_name: Diffs for Ref (${{ matrix.name }})
    output_filename: outputs.json
    ref: ${{ inputs.ref }}
    stack: ${{ matrix.name }}
    skip_synth: true
    terraform_version: ${{ inputs.terraform_version }}
    working_directory: ./cdktf
```

Run a test and confirm that the workflow runs faster now that a synth is no longer needed.