### PR TITLE
SRE-2650-cdktf-diff-fails-cant-get-job-id

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,14 +58,14 @@ runs:
         # We'll fetch pages of jobs and look for the one that matches JOB_NAME.
         found_job_id=''
         page=1
-        curl -f -s -D - -H "Accept: application/vnd.github.v3+json" \
+        curl --fail-with-body -s -D - -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: Bearer invalid_token" \
             "https://api.github.com/repos/snapsheet/cdktf-diff/actions/runs/1234/jobs"
 
         while [ -z "$found_job_id" ]; do
           echo "Fetching page $page of jobs."
           # Get both the response body and Link header in one request
-          response=$(curl -f -s -D - -H "Accept: application/vnd.github.v3+json" \
+          response=$(curl --fail-with-body -s -D - -H "Accept: application/vnd.github.v3+json" \
                         -H "Authorization: Bearer $GITHUB_TOKEN" \
                         "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100&page=${page}")
           

--- a/action.yml
+++ b/action.yml
@@ -58,14 +58,14 @@ runs:
         # We'll fetch pages of jobs and look for the one that matches JOB_NAME.
         found_job_id=''
         page=1
-        curl -s -D - -H "Accept: application/vnd.github.v3+json" \
+        curl -f -s -D - -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: Bearer invalid_token" \
             "https://api.github.com/repos/snapsheet/cdktf-diff/actions/runs/1234/jobs"
 
         while [ -z "$found_job_id" ]; do
           echo "Fetching page $page of jobs."
           # Get both the response body and Link header in one request
-          response=$(curl -s -D - -H "Accept: application/vnd.github.v3+json" \
+          response=$(curl -f -s -D - -H "Accept: application/vnd.github.v3+json" \
                         -H "Authorization: Bearer $GITHUB_TOKEN" \
                         "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100&page=${page}")
           

--- a/action.yml
+++ b/action.yml
@@ -82,8 +82,8 @@ runs:
             echo "html_url=$found_html_url" >> $GITHUB_OUTPUT
             break
           fi
-          # Extract the Link header and check If there's no 'next' link in the headers. We've reached the end.
           link_header=$(echo "$response" | grep -i ^Link: || true)
+          # Extract the Link header and check If there's no 'next' link in the headers. We've reached the end.
           if [[ "$link_header" != *'rel="next"'* ]]; then
             echo "Could not find the job with name $JOB_NAME after paginating."
             exit 1

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,9 @@ runs:
         # We'll fetch pages of jobs and look for the one that matches JOB_NAME.
         found_job_id=''
         page=1
+        curl -s -D - -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer invalid_token" \
+            "https://api.github.com/repos/snapsheet/cdktf-diff/actions/runs/1234/jobs"
 
         while [ -z "$found_job_id" ]; do
           echo "Fetching page $page of jobs."

--- a/action.yml
+++ b/action.yml
@@ -61,28 +61,29 @@ runs:
 
         while [ -z "$found_job_id" ]; do
           echo "Fetching page $page of jobs."
-          response=$(curl -s -H "Accept: application/vnd.github.v3+json" \
-                          -H "Authorization: Bearer $GITHUB_TOKEN" \
-                          "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100&page=${page}")
+          # Get both the response body and Link header in one request
+          response=$(curl -s -D - -H "Accept: application/vnd.github.v3+json" \
+                        -H "Authorization: Bearer $GITHUB_TOKEN" \
+                        "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100&page=${page}")
+          
 
-          # Use jq to find the job ID for the matching name.
-          found_job_id=$(echo "$response" | jq -r --arg jobName "$JOB_NAME" '.jobs[] | select(.name == $jobName) | .id')
+          
+          # Extract the JSON body everything after the blank line after headers.
+          json_response=$(echo "$response" | awk -v RS='\r\n\r\n' 'END{print}')
+          
+          # Use jq to find the job ID for the matching name
+          found_job_id=$(echo "$json_response" | jq -r --arg jobName "$JOB_NAME" '.jobs[] | select(.name == $jobName) | .id')
           if [ -n "$found_job_id" ] && [ "$found_job_id" != "null" ]; then
-            # If found, also grab the html_url.
-            found_html_url=$(echo "$response" | jq -r --arg jobName "$JOB_NAME" '.jobs[] | select(.name == $jobName) | .html_url')
-
+            # If found, also grab the html_url
+            found_html_url=$(echo "$json_response" | jq -r --arg jobName "$JOB_NAME" '.jobs[] | select(.name == $jobName) | .html_url')
+            
             echo "Found job with name: $JOB_NAME, ID: $found_job_id"
             echo "job_id=$found_job_id" >> $GITHUB_OUTPUT
             echo "html_url=$found_html_url" >> $GITHUB_OUTPUT
             break
           fi
-
-          # If there's no 'next' link in the headers. We've reached the end.
-          link_header=$(curl -sI -H "Accept: application/vnd.github.v3+json" \
-                              -H "Authorization: Bearer $GITHUB_TOKEN" \
-                              "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100&page=${page}" \
-                        | grep -i ^Link: || true)
-
+          # Extract the Link header and check If there's no 'next' link in the headers. We've reached the end.
+          link_header=$(echo "$response" | grep -i ^Link: || true)
           if [[ "$link_header" != *'rel="next"'* ]]; then
             echo "Could not find the job with name $JOB_NAME after paginating."
             exit 1

--- a/action.yml
+++ b/action.yml
@@ -58,9 +58,6 @@ runs:
         # We'll fetch pages of jobs and look for the one that matches JOB_NAME.
         found_job_id=''
         page=1
-        curl --fail-with-body -s -D - -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: Bearer invalid_token" \
-            "https://api.github.com/repos/snapsheet/cdktf-diff/actions/runs/1234/jobs"
 
         while [ -z "$found_job_id" ]; do
           echo "Fetching page $page of jobs."
@@ -68,9 +65,7 @@ runs:
           response=$(curl --fail-with-body -s -D - -H "Accept: application/vnd.github.v3+json" \
                         -H "Authorization: Bearer $GITHUB_TOKEN" \
                         "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100&page=${page}")
-          
-
-          
+                    
           # Extract the JSON body everything after the blank line after headers.
           json_response=$(echo "$response" | awk -v RS='\r\n\r\n' 'END{print}')
           

--- a/action.yml
+++ b/action.yml
@@ -48,12 +48,48 @@ outputs:
 runs:
   using: composite
   steps:
-    - id: jobid_action
-      uses: Tiryoh/gha-jobid-action@v1
-      with:
-        github_token: ${{ inputs.GITHUB_TOKEN }}
-        job_name: ${{ inputs.job_name }}
-        per_page: 100
+    - name: Retrieve Job ID with Pagination
+      id: jobid_action
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        JOB_NAME: ${{ inputs.job_name }}
+      run: |
+        # We'll fetch pages of jobs and look for the one that matches JOB_NAME.
+        found_job_id=''
+        page=1
+
+        while [ -z "$found_job_id" ]; do
+          echo "Fetching page $page of jobs."
+          response=$(curl -s -H "Accept: application/vnd.github.v3+json" \
+                          -H "Authorization: Bearer $GITHUB_TOKEN" \
+                          "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100&page=${page}")
+
+          # Use jq to find the job ID for the matching name.
+          found_job_id=$(echo "$response" | jq -r --arg jobName "$JOB_NAME" '.jobs[] | select(.name == $jobName) | .id')
+          if [ -n "$found_job_id" ] && [ "$found_job_id" != "null" ]; then
+            # If found, also grab the html_url.
+            found_html_url=$(echo "$response" | jq -r --arg jobName "$JOB_NAME" '.jobs[] | select(.name == $jobName) | .html_url')
+
+            echo "Found job with name: $JOB_NAME, ID: $found_job_id"
+            echo "job_id=$found_job_id" >> $GITHUB_OUTPUT
+            echo "html_url=$found_html_url" >> $GITHUB_OUTPUT
+            break
+          fi
+
+          # If there's no 'next' link in the headers. We've reached the end.
+          link_header=$(curl -sI -H "Accept: application/vnd.github.v3+json" \
+                              -H "Authorization: Bearer $GITHUB_TOKEN" \
+                              "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100&page=${page}" \
+                        | grep -i ^Link: || true)
+
+          if [[ "$link_header" != *'rel="next"'* ]]; then
+            echo "Could not find the job with name $JOB_NAME after paginating."
+            exit 1
+          fi
+
+          page=$((page + 1))
+        done
 
     - uses: hashicorp/setup-terraform@v3
       with:

--- a/action.yml
+++ b/action.yml
@@ -69,7 +69,7 @@ runs:
           # Extract the JSON body everything after the blank line after headers.
           json_response=$(echo "$response" | awk -v RS='\r\n\r\n' 'END{print}')
           
-          # Use jq to find the job ID for the matching name
+          # Use jq to try to find the job ID for the matching name
           found_job_id=$(echo "$json_response" | jq -r --arg jobName "$JOB_NAME" '.jobs[] | select(.name == $jobName) | .id')
           if [ -n "$found_job_id" ] && [ "$found_job_id" != "null" ]; then
             # If found, also grab the html_url


### PR DESCRIPTION
## What
This action in CDKTF Diff workflows will raise an error if there are too many stacks/environments.  

## Why
If the integrated project has more than 50 stacks when doubled(for default branch and ref branch), it maxes out the page size from the API request used to get the currently running job ID.

## How

### Code Explanation.  

```
response=$(curl -s -D - -H "Accept: application/vnd.github.v3+json" \
       -H "Authorization: Bearer $GITHUB_TOKEN" \
       "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs per_page=100&page=${page}")

json_response=$(echo "$response" | awk -v RS='\r\n\r\n' 'END{print}')
```
- Get both the response body and Link header in one request
- Extract json body from the respone which is separated by a blank line after the header 
<hr>

```
 found_job_id=$(echo "$json_response" | jq -r --arg jobName "$JOB_NAME" '.jobs[] | select(.name == $jobName) | .id')
```
- `echo "$json_response"` sends the API respons into  jq command.
- Then extracts the id of a job from a JSON response where the name matches the value of $JOB_NAME.

<hr>

```
  if [ -n "$found_job_id" ] && [ "$found_job_id" != "null" ]; then
       # If found, also grab the html_url.
       found_html_url=$(echo "$response" | jq -r --arg jobName "$JOB_NAME" '.jobs[] | select(.name == $jobName) | .html_url')
       echo "Found job with name: $JOB_NAME, ID: $found_job_id"
       echo "job_id=$found_job_id" >> $GITHUB_OUTPUT
       echo "html_url=$found_html_url" >> $GITHUB_OUTPUT
       break
  fi
```
- Check if the found_job_id is empty or equal to the string “null“.  If not then fetch the html_url using jq and assign $job_id and $html_url as an output of this github action(similar to the original action we are replacing).  

<hr>

```
    link_header=$(echo "$response" | grep -i ^Link: || true)
    if [[ "$link_header" != *'rel="next"'* ]]; then
              echo "Could not find the job with name $JOB_NAME after paginating."
              exit 1
    fi
```
- Check if a `Link` exists in the header for other pages.  If it does not set it to an empty string if grep fails.  
- If there is no string with rel=”next” inside that means we are on the last page and we could not find the job.  
[Pagination Github Link documentation ](https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28#using-link-headers)

