### PR TITLE
SRE-2560 Fix CDKTF Diff Output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -162,7 +162,7 @@ runs:
         if [ ! -f "$DIFF_FILE_PATH" ] || [ ! -s "$DIFF_FILE_PATH" ]; then
           echo "result_code=1" >> $GITHUB_OUTPUT
           echo "summary=Error: Diff command failed before producing output" >> $GITHUB_OUTPUT
-          exit 0 # exit with 0 so subsequent steps can run
+          exit 1
         fi
 
         # If planning failed due to an error, set the outputs and return.
@@ -173,7 +173,7 @@ runs:
             SUMMARY="Planning failed. Terraform encountered an error while generating this plan."
           fi
           echo "summary=$SUMMARY" >> $GITHUB_OUTPUT
-          exit 0 # return code zero so we don't break the rest of the workflow
+          exit 1
         fi        
 
         # If there are no changes, set the outputs and return.
@@ -208,13 +208,13 @@ runs:
               echo "summary=Error: Diff command failed with exit code $DIFF_EXIT_CODE" >> $GITHUB_OUTPUT
             fi
           fi
-          exit 0 # exit with 0 so subsequent steps can run
+          exit $DIFF_EXIT_CODE
         fi
 
         # If we get here, we couldn't determine the result
         echo "result_code=1" >> $GITHUB_OUTPUT
         echo "summary=Error: Could not determine if diff ran successfully" >> $GITHUB_OUTPUT
-        exit 0 # exit with 0 so subsequent steps can run
+        exit 1
 
     - name: Dump Outputs to File
       if: always()

--- a/action.yml
+++ b/action.yml
@@ -130,6 +130,10 @@ runs:
       run: |
         cd ${{ inputs.working_directory }}
 
+        # Initialize default outputs in case of failure
+        echo "result_code=1" >> $GITHUB_OUTPUT
+        echo "summary=Error: Diff execution failed" >> $GITHUB_OUTPUT
+
         # If stub_output_file is present, set the execution command to output this file instead of running diff.
         # Assignment uses single quotes explicitly to prevent possible code injection.
         if [ -f "${{ inputs.stub_output_file }}" ]; then
@@ -147,12 +151,27 @@ runs:
 
         # show output in CLI/GitHub and also send to file for later parsing
         DIFF_FILE_PATH="${TMPDIR}cdktf-diff.txt"
-        eval $DIFF_COMMAND | tee $DIFF_FILE_PATH
+
+        # Run the command and capture exit code, but don't fail the step yet
+        set +e
+        eval $DIFF_COMMAND 2>&1 | tee $DIFF_FILE_PATH
+        DIFF_EXIT_CODE=${PIPESTATUS[0]}
+        set -e
+
+        # Check if the diff file was created and has content
+        if [ ! -f "$DIFF_FILE_PATH" ] || [ ! -s "$DIFF_FILE_PATH" ]; then
+          echo "result_code=1" >> $GITHUB_OUTPUT
+          echo "summary=Error: Diff command failed before producing output" >> $GITHUB_OUTPUT
+          exit 0 # exit with 0 so subsequent steps can run
+        fi
 
         # If planning failed due to an error, set the outputs and return.
         if cat $DIFF_FILE_PATH | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | grep "Planning failed. Terraform encountered an error while generating this plan." > /dev/null ; then
           echo "result_code=1" >> $GITHUB_OUTPUT
-          SUMMARY=$(cat $DIFF_FILE_PATH | grep "Error: " | xargs | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g")
+          SUMMARY=$(cat $DIFF_FILE_PATH | grep "Error: " | head -1 | xargs | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g")
+          if [ -z "$SUMMARY" ]; then
+            SUMMARY="Planning failed. Terraform encountered an error while generating this plan."
+          fi
           echo "summary=$SUMMARY" >> $GITHUB_OUTPUT
           exit 0 # return code zero so we don't break the rest of the workflow
         fi        
@@ -173,17 +192,69 @@ runs:
           exit 0 # return code zero so we don't break the rest of the workflow
         fi
 
-        echo "Error: Could not determine if diff ran successfully."
-        echo "result_code=1"
-        exit 1
+        # If command failed but we couldn't parse the output, try to extract error message
+        if [ $DIFF_EXIT_CODE -ne 0 ]; then
+          echo "result_code=1" >> $GITHUB_OUTPUT
+          # Try to extract error message from the output
+          ERROR_MSG=$(cat $DIFF_FILE_PATH | grep -i "Error:" | head -1 | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | xargs || true)
+          if [ -n "$ERROR_MSG" ]; then
+            echo "summary=$ERROR_MSG" >> $GITHUB_OUTPUT
+          else
+            # Fallback: get last few lines that might contain error info
+            ERROR_MSG=$(tail -5 $DIFF_FILE_PATH | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | tr '\n' ' ' | xargs || true)
+            if [ -n "$ERROR_MSG" ]; then
+              echo "summary=$ERROR_MSG" >> $GITHUB_OUTPUT
+            else
+              echo "summary=Error: Diff command failed with exit code $DIFF_EXIT_CODE" >> $GITHUB_OUTPUT
+            fi
+          fi
+          exit 0 # exit with 0 so subsequent steps can run
+        fi
+
+        # If we get here, we couldn't determine the result
+        echo "result_code=1" >> $GITHUB_OUTPUT
+        echo "summary=Error: Could not determine if diff ran successfully" >> $GITHUB_OUTPUT
+        exit 0 # exit with 0 so subsequent steps can run
 
     - name: Dump Outputs to File
+      if: always()
       shell: bash
       run: |
-        TOTAL_OUTPUTS='{"result_code":${{ steps.diff.outputs.result_code }},"summary":"${{ steps.diff.outputs.summary }}","html_url":"${{ steps.jobid_action.outputs.html_url }}","stack":"${{ inputs.stack }}","job_id":"${{ steps.jobid_action.outputs.job_id }}","node_version":"${{ steps.configurations.outputs.node_version }}","terraform_version":"${{ inputs.terraform_version }}"}'
+        # Set default values if outputs are not set (e.g., if diff step failed before setting them)
+        RESULT_CODE="${{ steps.diff.outputs.result_code }}"
+        SUMMARY="${{ steps.diff.outputs.summary }}"
+        HTML_URL="${{ steps.jobid_action.outputs.html_url }}"
+        JOB_ID="${{ steps.jobid_action.outputs.job_id }}"
+        NODE_VERSION="${{ steps.configurations.outputs.node_version }}"
+        TERRAFORM_VERSION="${{ inputs.terraform_version }}"
+        STACK="${{ inputs.stack }}"
+
+        # Use defaults if values are empty
+        if [ -z "$RESULT_CODE" ]; then
+          RESULT_CODE="1"
+        fi
+        if [ -z "$SUMMARY" ]; then
+          SUMMARY="Error: Job failed before outputs could be determined"
+        fi
+        if [ -z "$HTML_URL" ]; then
+          HTML_URL=""
+        fi
+        if [ -z "$JOB_ID" ]; then
+          JOB_ID=""
+        fi
+        if [ -z "$NODE_VERSION" ]; then
+          NODE_VERSION=""
+        fi
+
+        # Escape quotes in summary for JSON
+        SUMMARY_ESCAPED=$(echo "$SUMMARY" | sed 's/"/\\"/g')
+
+        # Create JSON output
+        TOTAL_OUTPUTS="{\"result_code\":${RESULT_CODE},\"summary\":\"${SUMMARY_ESCAPED}\",\"html_url\":\"${HTML_URL}\",\"stack\":\"${STACK}\",\"job_id\":\"${JOB_ID}\",\"node_version\":\"${NODE_VERSION}\",\"terraform_version\":\"${TERRAFORM_VERSION}\"}"
         echo $TOTAL_OUTPUTS > ${{ inputs.working_directory }}/${{ inputs.output_filename }}
 
     - uses: actions/upload-artifact@v4
+      if: always()
       name: Save Outputs
       with:
         name: ${{ steps.jobid_action.outputs.job_id }}

--- a/action.yml
+++ b/action.yml
@@ -168,7 +168,7 @@ runs:
         # If planning failed due to an error, set the outputs and return.
         if cat $DIFF_FILE_PATH | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | grep "Planning failed. Terraform encountered an error while generating this plan." > /dev/null ; then
           echo "result_code=1" >> $GITHUB_OUTPUT
-          SUMMARY=$(cat $DIFF_FILE_PATH | grep "Error: " | head -1 | xargs | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g")
+          SUMMARY=$(cat $DIFF_FILE_PATH | grep "Error: " | head -1 | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed 's/^[[:space:]]*│[[:space:]]*//' | xargs)
           if [ -z "$SUMMARY" ]; then
             SUMMARY="Planning failed. Terraform encountered an error while generating this plan."
           fi
@@ -187,7 +187,7 @@ runs:
         # If there is a plan, set the outputs and return.
         if cat $DIFF_FILE_PATH | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | grep "Plan:" > /dev/null ; then
           echo "result_code=2" >> $GITHUB_OUTPUT
-          SUMMARY=$(cat $DIFF_FILE_PATH | grep "Plan:" | xargs | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g")
+          SUMMARY=$(cat $DIFF_FILE_PATH | grep "Plan:" | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed 's/.*Plan:/Plan:/' | xargs)
           echo "summary=$SUMMARY" >> $GITHUB_OUTPUT
           exit 0 # return code zero so we don't break the rest of the workflow
         fi
@@ -196,12 +196,12 @@ runs:
         if [ $DIFF_EXIT_CODE -ne 0 ]; then
           echo "result_code=1" >> $GITHUB_OUTPUT
           # Try to extract error message from the output
-          ERROR_MSG=$(cat $DIFF_FILE_PATH | grep -i "Error:" | head -1 | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | xargs || true)
+          ERROR_MSG=$(cat $DIFF_FILE_PATH | grep -i "Error:" | head -1 | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed 's/^[[:space:]]*│[[:space:]]*//' | xargs || true)
           if [ -n "$ERROR_MSG" ]; then
             echo "summary=$ERROR_MSG" >> $GITHUB_OUTPUT
           else
             # Fallback: get last few lines that might contain error info
-            ERROR_MSG=$(tail -5 $DIFF_FILE_PATH | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | tr '\n' ' ' | xargs || true)
+            ERROR_MSG=$(tail -5 $DIFF_FILE_PATH | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed 's/^[[:space:]]*│[[:space:]]*//' | tr '\n' ' ' | xargs || true)
             if [ -n "$ERROR_MSG" ]; then
               echo "summary=$ERROR_MSG" >> $GITHUB_OUTPUT
             else


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-2560
## What

Changes the jobs for writing the output/result to always run even if the diff fails.

## Why

Previously, if one of the cdktf-diff matrix jobs failed, it would skip the output and no summary would be printed out. This makes it tedious to copy plan links into PRs for review.

## How

Sets the output jobs to always run and initializes default output variables. Also, adds some additional error parsing to display in the summary.

## Testing

See this [run](https://github.com/bodyshopbidsdotcom/dispatch/actions/runs/21019374803) - specifically the `dispatch-release` env.
