### PR TITLE
Release 0.2.2 Hot Fix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -168,7 +168,7 @@ runs:
         # If planning failed due to an error, set the outputs and return.
         if cat $DIFF_FILE_PATH | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | grep "Planning failed. Terraform encountered an error while generating this plan." > /dev/null ; then
           echo "result_code=1" >> $GITHUB_OUTPUT
-          SUMMARY=$(cat $DIFF_FILE_PATH | grep "Error: " | head -1 | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed 's/^[[:space:]]*│[[:space:]]*//' | xargs)
+          SUMMARY=$(cat $DIFF_FILE_PATH | grep "Error: " | head -1 | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed 's/^[[:space:]]*│[[:space:]]*//' | sed -r 's/^::(error|warning|notice|debug):: *//' | xargs)
           if [ -z "$SUMMARY" ]; then
             SUMMARY="Planning failed. Terraform encountered an error while generating this plan."
           fi
@@ -196,12 +196,12 @@ runs:
         if [ $DIFF_EXIT_CODE -ne 0 ]; then
           echo "result_code=1" >> $GITHUB_OUTPUT
           # Try to extract error message from the output
-          ERROR_MSG=$(cat $DIFF_FILE_PATH | grep -i "Error:" | head -1 | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed 's/^[[:space:]]*│[[:space:]]*//' | xargs || true)
+          ERROR_MSG=$(cat $DIFF_FILE_PATH | grep -i "Error:" | head -1 | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed 's/^[[:space:]]*│[[:space:]]*//' | sed -r 's/^::(error|warning|notice|debug):: *//' | xargs || true)
           if [ -n "$ERROR_MSG" ]; then
             echo "summary=$ERROR_MSG" >> $GITHUB_OUTPUT
           else
             # Fallback: get last few lines that might contain error info
-            ERROR_MSG=$(tail -5 $DIFF_FILE_PATH | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed 's/^[[:space:]]*│[[:space:]]*//' | tr '\n' ' ' | xargs || true)
+            ERROR_MSG=$(tail -5 $DIFF_FILE_PATH | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed 's/^[[:space:]]*│[[:space:]]*//' | sed -r 's/^::(error|warning|notice|debug):: *//' | tr '\n' ' ' | xargs || true)
             if [ -n "$ERROR_MSG" ]; then
               echo "summary=$ERROR_MSG" >> $GITHUB_OUTPUT
             else

--- a/action.yml
+++ b/action.yml
@@ -168,7 +168,7 @@ runs:
         # If planning failed due to an error, set the outputs and return.
         if cat $DIFF_FILE_PATH | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | grep "Planning failed. Terraform encountered an error while generating this plan." > /dev/null ; then
           echo "result_code=1" >> $GITHUB_OUTPUT
-          SUMMARY=$(cat $DIFF_FILE_PATH | grep "Error: " | head -1 | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed 's/^[[:space:]]*│[[:space:]]*//' | sed -r 's/^::(error|warning|notice|debug):: *//' | xargs)
+          SUMMARY=$(cat $DIFF_FILE_PATH | grep "Error: " | head -1 | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed 's/^[[:space:]]*│[[:space:]]*//' | xargs)
           if [ -z "$SUMMARY" ]; then
             SUMMARY="Planning failed. Terraform encountered an error while generating this plan."
           fi
@@ -196,12 +196,12 @@ runs:
         if [ $DIFF_EXIT_CODE -ne 0 ]; then
           echo "result_code=1" >> $GITHUB_OUTPUT
           # Try to extract error message from the output
-          ERROR_MSG=$(cat $DIFF_FILE_PATH | grep -i "Error:" | head -1 | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed 's/^[[:space:]]*│[[:space:]]*//' | sed -r 's/^::(error|warning|notice|debug):: *//' | xargs || true)
+          ERROR_MSG=$(cat $DIFF_FILE_PATH | grep -i "Error:" | head -1 | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed 's/^[[:space:]]*│[[:space:]]*//' | xargs || true)
           if [ -n "$ERROR_MSG" ]; then
             echo "summary=$ERROR_MSG" >> $GITHUB_OUTPUT
           else
             # Fallback: get last few lines that might contain error info
-            ERROR_MSG=$(tail -5 $DIFF_FILE_PATH | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed 's/^[[:space:]]*│[[:space:]]*//' | sed -r 's/^::(error|warning|notice|debug):: *//' | tr '\n' ' ' | xargs || true)
+            ERROR_MSG=$(tail -5 $DIFF_FILE_PATH | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed 's/^[[:space:]]*│[[:space:]]*//' | tr '\n' ' ' | xargs || true)
             if [ -n "$ERROR_MSG" ]; then
               echo "summary=$ERROR_MSG" >> $GITHUB_OUTPUT
             else
@@ -236,6 +236,10 @@ runs:
         if [ -z "$SUMMARY" ]; then
           SUMMARY="Error: Job failed before outputs could be determined"
         fi
+
+        # Strip GitHub Actions log prefix if present
+        SUMMARY=$(echo "$SUMMARY" | sed -r 's/^::(error|warning|notice|debug):: *//')
+
         if [ -z "$HTML_URL" ]; then
           HTML_URL=""
         fi

--- a/action.yml
+++ b/action.yml
@@ -184,8 +184,8 @@ runs:
           exit 0
         fi
 
-        # If there is a plan, set the outputs and return.
-        if cat $DIFF_FILE_PATH | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | grep "Plan:" > /dev/null ; then
+        # If there is a plan and the command succeeded, set the outputs and return.
+        if cat $DIFF_FILE_PATH | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | grep "Plan:" > /dev/null && [ $DIFF_EXIT_CODE -eq 0 ]; then
           echo "result_code=2" >> $GITHUB_OUTPUT
           SUMMARY=$(cat $DIFF_FILE_PATH | grep "Plan:" | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | sed 's/.*Plan:/Plan:/' | xargs)
           echo "summary=$SUMMARY" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-2560
## What

There are certain scenarios in which a CDKTF plan may be generated, but the actual command failed (ex: failed data lookups). See [here](https://github.com/bodyshopbidsdotcom/vice-backend/actions/runs/22147906812/job/64031009527).

## Why

Even though a plan may generated, the overall CDKTF action failed and should fail accordingly

## How

Adds an additional exit code check even when a plan is generated.

## Testing

Run the [cdktf-diff](https://github.com/bodyshopbidsdotcom/vice-backend/actions/workflows/cdktf_diff_workflow_dispatch.yml) action in vice-backend from the 	`SRE-2560-fix-cdktf-diff-output` branch.

See post change run [here](https://github.com/bodyshopbidsdotcom/vice-backend/actions/runs/22149549219).
See pre change run [here](https://github.com/bodyshopbidsdotcom/vice-backend/actions/runs/22147906812/job/64031009527).