### PR TITLE
SRE-2560 Fix CDKTF Diff Output

### DIFF
--- a/__tests__/runDiff.test.ts
+++ b/__tests__/runDiff.test.ts
@@ -6,13 +6,19 @@ import * as exec from "@actions/exec";
 import * as fs from "fs";
 import * as path from "path";
 
+// Mock fs.writeFileSync so we can assert on it without touching disk; keep rest of fs for cleanup
+jest.mock("fs", () => ({
+  ...jest.requireActual<typeof import("fs")>("fs"),
+  writeFileSync: jest.fn(),
+}));
+
 // Mock all external dependencies
 jest.mock("@actions/core", () => ({
   getInput: jest.fn(),
   getBooleanInput: jest.fn(),
   setOutput: jest.fn(),
   setFailed: jest.fn(),
-  debug: jest.fn()
+  debug: jest.fn(),
 }));
 
 jest.mock("@actions/github");
@@ -29,30 +35,33 @@ describe("RunDiff", () => {
     stack: "test-stack",
     terraform_version: "1.8.0",
     working_directory: "./",
-    skip_synth: "false"
+    skip_synth: "false",
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
-    
+
     // `Setup` core.getInput mock
-    (core.getInput as jest.Mock).mockImplementation((name: string) => 
-      mockInputs[name as keyof typeof mockInputs]
+    (core.getInput as jest.Mock).mockImplementation(
+      (name: string) => mockInputs[name as keyof typeof mockInputs],
     );
-    (core.getBooleanInput as jest.Mock).mockImplementation((name: string) => 
-      mockInputs[name as keyof typeof mockInputs] === "true"
+    (core.getBooleanInput as jest.Mock).mockImplementation(
+      (name: string) => mockInputs[name as keyof typeof mockInputs] === "true",
     );
 
     // Setup github.context
     (github.context as unknown) = {
       repo: { owner: "test-owner", repo: "test-repo" },
-      runId: 12345
+      runId: 12345,
     };
   });
 
   // Clean up after all tests
   afterAll(() => {
-    const outputPath = path.join(mockInputs.working_directory, mockInputs.output_filename);
+    const outputPath = path.join(
+      mockInputs.working_directory,
+      mockInputs.output_filename,
+    );
     try {
       fs.unlinkSync(outputPath);
     } catch (error) {
@@ -72,21 +81,23 @@ describe("RunDiff", () => {
         status: "completed",
         conclusion: "success",
         started_at: faker.date.recent().toISOString(),
-        completed_at: faker.date.recent().toISOString()
+        completed_at: faker.date.recent().toISOString(),
       };
 
       // Create mock paginated response
       const mockJobs = [
-        ...Array(250).fill(null).map(() => ({
-          id: faker.number.int({ min: 1000, max: 9999 }),
-          name: "other-job",
-          html_url: faker.internet.url(),
-          status: "completed",
-          conclusion: "success",
-          started_at: faker.date.recent().toISOString(),
-          completed_at: faker.date.recent().toISOString()
-        })),
-        targetJob
+        ...Array(250)
+          .fill(null)
+          .map(() => ({
+            id: faker.number.int({ min: 1000, max: 9999 }),
+            name: "other-job",
+            html_url: faker.internet.url(),
+            status: "completed",
+            conclusion: "success",
+            started_at: faker.date.recent().toISOString(),
+            completed_at: faker.date.recent().toISOString(),
+          })),
+        targetJob,
       ];
 
       // Mock Octokit paginate to return all jobs
@@ -96,9 +107,9 @@ describe("RunDiff", () => {
         paginate: mockPaginate,
         rest: {
           actions: {
-            listJobsForWorkflowRun: jest.fn()
-          }
-        }
+            listJobsForWorkflowRun: jest.fn(),
+          },
+        },
       });
 
       const runDiff = new RunDiff();
@@ -107,19 +118,16 @@ describe("RunDiff", () => {
       // Verify the correct job was found
       expect(result).toEqual({
         job_id: targetJob.id,
-        html_url: targetJob.html_url
+        html_url: targetJob.html_url,
       });
 
       // Verify paginate was called correctly
       expect(mockPaginate).toHaveBeenCalledTimes(1);
-      expect(mockPaginate).toHaveBeenCalledWith(
-        expect.any(Function),
-        {
-          owner: "test-owner",
-          repo: "test-repo",
-          run_id: 12345
-        }
-      );
+      expect(mockPaginate).toHaveBeenCalledWith(expect.any(Function), {
+        owner: "test-owner",
+        repo: "test-repo",
+        run_id: 12345,
+      });
     });
 
     it("should throw an error if the workflow run cannot be found (octokit.paginate rejects)", async () => {
@@ -130,9 +138,9 @@ describe("RunDiff", () => {
         paginate: mockPaginate,
         rest: {
           actions: {
-            listJobsForWorkflowRun: jest.fn()
-          }
-        }
+            listJobsForWorkflowRun: jest.fn(),
+          },
+        },
       });
 
       const runDiff = new RunDiff();
@@ -146,15 +154,17 @@ describe("RunDiff", () => {
 
     it("should throw error when job is not found after pagination", async () => {
       // Create mock paginated response with no matching job
-      const mockJobs = Array(50).fill(null).map(() => ({
-        id: faker.number.int({ min: 1000, max: 9999 }),
-        name: "different-job",
-        html_url: faker.internet.url(),
-        status: "completed",
-        conclusion: "success",
-        started_at: faker.date.recent().toISOString(),
-        completed_at: faker.date.recent().toISOString()
-      }));
+      const mockJobs = Array(50)
+        .fill(null)
+        .map(() => ({
+          id: faker.number.int({ min: 1000, max: 9999 }),
+          name: "different-job",
+          html_url: faker.internet.url(),
+          status: "completed",
+          conclusion: "success",
+          started_at: faker.date.recent().toISOString(),
+          completed_at: faker.date.recent().toISOString(),
+        }));
 
       // Mock Octokit to return a single page with no matching job
       const mockPaginate = jest.fn().mockResolvedValue(mockJobs);
@@ -163,70 +173,183 @@ describe("RunDiff", () => {
         paginate: mockPaginate,
         rest: {
           actions: {
-            listJobsForWorkflowRun: jest.fn()
-          }
-        }
+            listJobsForWorkflowRun: jest.fn(),
+          },
+        },
       });
 
       const runDiff = new RunDiff();
-      
+
       // Verify that getJobInformation throws with the correct error message
       await expect(runDiff.getJobInformation()).rejects.toThrow(
-        `Could not find job with name ${mockInputs.job_name}`
+        `Could not find job with name ${mockInputs.job_name}`,
       );
 
       // Verify paginate was called correctly
       expect(mockPaginate).toHaveBeenCalledTimes(1);
-      expect(mockPaginate).toHaveBeenCalledWith(
-        expect.any(Function),
-        {
-          owner: "test-owner",
-          repo: "test-repo",
-          run_id: 12345
-        }
-      );
+      expect(mockPaginate).toHaveBeenCalledWith(expect.any(Function), {
+        owner: "test-owner",
+        repo: "test-repo",
+        run_id: 12345,
+      });
+    });
+
+    it("should return empty string for html_url when job has no html_url", async () => {
+      const jobWithoutUrl = {
+        id: 99999,
+        name: "target-job",
+        html_url: undefined,
+        status: "completed",
+        conclusion: "success",
+        started_at: faker.date.recent().toISOString(),
+        completed_at: faker.date.recent().toISOString(),
+      };
+
+      const mockPaginate = jest.fn().mockResolvedValue([jobWithoutUrl]);
+
+      (github.getOctokit as jest.Mock).mockReturnValue({
+        paginate: mockPaginate,
+        rest: {
+          actions: {
+            listJobsForWorkflowRun: jest.fn(),
+          },
+        },
+      });
+
+      const runDiff = new RunDiff();
+      const result = await runDiff.getJobInformation();
+
+      expect(result).toEqual({
+        job_id: 99999,
+        html_url: "",
+      });
     });
   });
 
   describe("runDiff", () => {
-    it("should handle failed planning with error", async () => {
-      // Mock exec to simulate failed planning
-      (exec.exec as jest.Mock).mockImplementation((_cmd: string, _args: string[], opts?: { listeners?: { stdout?: (data: Buffer) => void } }) => {
-        if (opts?.listeners?.stdout) {
-          opts.listeners.stdout(Buffer.from(
-            "Planning failed. Terraform encountered an error while generating this plan.\nError: Invalid configuration"
-          ));
-        }
-        return Promise.resolve(1);
-      });
+    it("should handle failed planning with generic exit code message", async () => {
+      // Mock exec to simulate failed planning (non-zero exit; no special error text)
+      (exec.exec as jest.Mock).mockImplementation(
+        (
+          _cmd: string,
+          _args: string[],
+          opts?: { listeners?: { stdout?: (data: Buffer) => void } },
+        ) => {
+          if (opts?.listeners?.stdout) {
+            opts.listeners.stdout(
+              Buffer.from(
+                "Planning failed. Terraform encountered an error while generating this plan.\nError: Invalid configuration",
+              ),
+            );
+          }
+          return Promise.resolve(1);
+        },
+      );
 
       const runDiff = new RunDiff();
       const result = await runDiff.runDiff();
 
-      // Verify the error is handled correctly
+      // Verify the error is handled correctly (generic non-zero exit message)
       expect(result).toEqual({
         result_code: "1",
-        summary: "Error: Invalid configuration"
+        summary: "Plan failed with exit code 1. See run for details.",
       });
 
       // Verify exec was called with correct command
       expect(exec.exec).toHaveBeenCalledWith(
         "bash",
         ["-c", `CI=1 npx cdktf diff ${mockInputs.stack}`],
-        expect.any(Object)
+        expect.any(Object),
       );
+    });
+
+    it("should handle DynamoDB throttling error (ProvisionedThroughputExceededException)", async () => {
+      (exec.exec as jest.Mock).mockImplementation(
+        (
+          _cmd: string,
+          _args: string[],
+          opts?: { listeners?: { stdout?: (data: Buffer) => void } },
+        ) => {
+          if (opts?.listeners?.stdout) {
+            opts.listeners.stdout(
+              Buffer.from(
+                "Error: ProvisionedThroughputExceededException: The level of configured provisioned throughput for the table was exceeded.",
+              ),
+            );
+          }
+          return Promise.resolve(1);
+        },
+      );
+
+      const runDiff = new RunDiff();
+      const result = await runDiff.runDiff();
+
+      expect(result).toEqual({
+        result_code: "1",
+        summary:
+          "DynamoDB is throttling state lock requests. See run for details.",
+      });
+    });
+
+    it("should handle state lock error (Error acquiring the state lock)", async () => {
+      (exec.exec as jest.Mock).mockImplementation(
+        (
+          _cmd: string,
+          _args: string[],
+          opts?: { listeners?: { stdout?: (data: Buffer) => void } },
+        ) => {
+          if (opts?.listeners?.stdout) {
+            opts.listeners.stdout(
+              Buffer.from(
+                "Error acquiring the state lock. Another process is holding the lock.",
+              ),
+            );
+          }
+          return Promise.resolve(1);
+        },
+      );
+
+      const runDiff = new RunDiff();
+      const result = await runDiff.runDiff();
+
+      expect(result).toEqual({
+        result_code: "1",
+        summary: "Error acquiring the state lock. See run for details.",
+      });
+    });
+
+    it("should return error when exec throws", async () => {
+      (exec.exec as jest.Mock).mockRejectedValue(
+        new Error("Exec failed: command not found"),
+      );
+
+      const runDiff = new RunDiff();
+      const result = await runDiff.runDiff();
+
+      expect(result).toEqual({
+        result_code: "1",
+        summary: "Exec failed: command not found",
+      });
     });
 
     it("should handle no changes scenario", async () => {
       // Mock exec to simulate no changes output
-      (exec.exec as jest.Mock).mockImplementation((_cmd: string, _args: string[], opts?: { listeners?: { stdout?: (data: Buffer) => void } }) => {
-        if (opts?.listeners?.stdout) {
-          opts.listeners.stdout(Buffer.from(
-            "No changes. Your infrastructure matches the configuration."
-          ));
-        }
-        return Promise.resolve(0);
-      });
+      (exec.exec as jest.Mock).mockImplementation(
+        (
+          _cmd: string,
+          _args: string[],
+          opts?: { listeners?: { stdout?: (data: Buffer) => void } },
+        ) => {
+          if (opts?.listeners?.stdout) {
+            opts.listeners.stdout(
+              Buffer.from(
+                "No changes. Your infrastructure matches the configuration.",
+              ),
+            );
+          }
+          return Promise.resolve(0);
+        },
+      );
 
       const runDiff = new RunDiff();
       const result = await runDiff.runDiff();
@@ -234,27 +357,33 @@ describe("RunDiff", () => {
       // Verify the no changes case is handled correctly
       expect(result).toEqual({
         result_code: "0",
-        summary: "No changes. Your infrastructure matches the configuration."
+        summary: "No changes. Your infrastructure matches the configuration.",
       });
 
       // Verify exec was called with correct command
       expect(exec.exec).toHaveBeenCalledWith(
         "bash",
         ["-c", `CI=1 npx cdktf diff ${mockInputs.stack}`],
-        expect.any(Object)
+        expect.any(Object),
       );
     });
 
     it("should handle pending changes scenario", async () => {
       const planSummary = "Plan: 1 to add, 2 to change, 3 to destroy.";
-      
+
       // Mock exec to simulate output with pending changes
-      (exec.exec as jest.Mock).mockImplementation((_cmd: string, _args: string[], opts?: { listeners?: { stdout?: (data: Buffer) => void } }) => {
-        if (opts?.listeners?.stdout) {
-          opts.listeners.stdout(Buffer.from(planSummary));
-        }
-        return Promise.resolve(0);
-      });
+      (exec.exec as jest.Mock).mockImplementation(
+        (
+          _cmd: string,
+          _args: string[],
+          opts?: { listeners?: { stdout?: (data: Buffer) => void } },
+        ) => {
+          if (opts?.listeners?.stdout) {
+            opts.listeners.stdout(Buffer.from(planSummary));
+          }
+          return Promise.resolve(0);
+        },
+      );
 
       const runDiff = new RunDiff();
       const result = await runDiff.runDiff();
@@ -262,27 +391,35 @@ describe("RunDiff", () => {
       // Verify the pending changes case is handled correctly
       expect(result).toEqual({
         result_code: "2",
-        summary: planSummary
+        summary: planSummary,
       });
 
       // Verify exec was called with correct command
       expect(exec.exec).toHaveBeenCalledWith(
         "bash",
         ["-c", `CI=1 npx cdktf diff ${mockInputs.stack}`],
-        expect.any(Object)
+        expect.any(Object),
       );
     });
 
     it("should handle indeterminate diff result", async () => {
       // Mock exec to simulate unexpected output
-      (exec.exec as jest.Mock).mockImplementation((_cmd: string, _args: string[], opts?: { listeners?: { stdout?: (data: Buffer) => void } }) => {
-        if (opts?.listeners?.stdout) {
-          opts.listeners.stdout(Buffer.from(
-            "Some unexpected output that doesn't match any known patterns"
-          ));
-        }
-        return Promise.resolve(0);
-      });
+      (exec.exec as jest.Mock).mockImplementation(
+        (
+          _cmd: string,
+          _args: string[],
+          opts?: { listeners?: { stdout?: (data: Buffer) => void } },
+        ) => {
+          if (opts?.listeners?.stdout) {
+            opts.listeners.stdout(
+              Buffer.from(
+                "Some unexpected output that doesn't match any known patterns",
+              ),
+            );
+          }
+          return Promise.resolve(0);
+        },
+      );
 
       const runDiff = new RunDiff();
       const result = await runDiff.runDiff();
@@ -290,30 +427,73 @@ describe("RunDiff", () => {
       // Verify the unknown error case is handled correctly
       expect(result).toEqual({
         result_code: "1",
-        summary: "Could not determine if diff ran successfully"
+        summary: "Could not determine if diff ran successfully",
       });
 
       // Verify exec was called with correct command
       expect(exec.exec).toHaveBeenCalledWith(
         "bash",
         ["-c", `CI=1 npx cdktf diff ${mockInputs.stack}`],
-        expect.any(Object)
+        expect.any(Object),
+      );
+    });
+
+    it("should use default terraform_version and working_directory when inputs are empty", async () => {
+      (core.getInput as jest.Mock).mockImplementation((name: string) => {
+        if (name === "terraform_version" || name === "working_directory")
+          return "";
+        return mockInputs[name as keyof typeof mockInputs];
+      });
+      (exec.exec as jest.Mock).mockImplementation(
+        (
+          _cmd: string,
+          _args: string[],
+          opts?: { listeners?: { stdout?: (data: Buffer) => void } },
+        ) => {
+          if (opts?.listeners?.stdout) {
+            opts.listeners.stdout(
+              Buffer.from(
+                "No changes. Your infrastructure matches the configuration.",
+              ),
+            );
+          }
+          return Promise.resolve(0);
+        },
+      );
+
+      const runDiff = new RunDiff();
+      const result = await runDiff.runDiff();
+
+      expect(result.result_code).toBe("0");
+      // Constructor used defaults: terraform_version "1.8.0", working_directory "./"
+      expect(exec.exec).toHaveBeenCalledWith(
+        "bash",
+        ["-c", `CI=1 npx cdktf diff ${mockInputs.stack}`],
+        expect.objectContaining({ cwd: "./" }),
       );
     });
 
     it("should add skip-synth flag when input is true", async () => {
       // Set skip-synth input to true
-      (core.getBooleanInput as jest.Mock).mockImplementation((name: string) => 
-        name === "skip_synth" ? true : mockInputs[name as keyof typeof mockInputs] === "true"
+      (core.getBooleanInput as jest.Mock).mockImplementation((name: string) =>
+        name === "skip_synth"
+          ? true
+          : mockInputs[name as keyof typeof mockInputs] === "true",
       );
 
       // Mock exec to simulate no changes output
-      (exec.exec as jest.Mock).mockImplementation((_cmd: string, _args: string[], opts?: { listeners?: { stdout?: (data: Buffer) => void } }) => {
-        if (opts?.listeners?.stdout) {
-          opts.listeners.stdout(Buffer.from("No changes"));
-        }
-        return Promise.resolve(0);
-      });
+      (exec.exec as jest.Mock).mockImplementation(
+        (
+          _cmd: string,
+          _args: string[],
+          opts?: { listeners?: { stdout?: (data: Buffer) => void } },
+        ) => {
+          if (opts?.listeners?.stdout) {
+            opts.listeners.stdout(Buffer.from("No changes"));
+          }
+          return Promise.resolve(0);
+        },
+      );
 
       const runDiff = new RunDiff();
       await runDiff.runDiff();
@@ -322,7 +502,7 @@ describe("RunDiff", () => {
       expect(exec.exec).toHaveBeenCalledWith(
         "bash",
         ["-c", `CI=1 npx cdktf diff --skip-synth ${mockInputs.stack}`],
-        expect.any(Object)
+        expect.any(Object),
       );
     });
 
@@ -333,20 +513,27 @@ describe("RunDiff", () => {
         if (name === "stub_output_file") return stubFile;
         return mockInputs[name as keyof typeof mockInputs];
       });
-      (core.getBooleanInput as jest.Mock).mockImplementation((name: string) =>
-        mockInputs[name as keyof typeof mockInputs] === "true"
+      (core.getBooleanInput as jest.Mock).mockImplementation(
+        (name: string) =>
+          mockInputs[name as keyof typeof mockInputs] === "true",
       );
 
       let calledCommand = "";
       let calledArgs: string[] = [];
-      (exec.exec as jest.Mock).mockImplementation((cmd: string, args: string[], opts?: any) => {
-        calledCommand = cmd;
-        calledArgs = args;
-        if (opts?.listeners?.stdout) {
-          opts.listeners.stdout(Buffer.from("No changes. Your infrastructure matches the configuration."));
-        }
-        return Promise.resolve(0);
-      });
+      (exec.exec as jest.Mock).mockImplementation(
+        (cmd: string, args: string[], opts?: any) => {
+          calledCommand = cmd;
+          calledArgs = args;
+          if (opts?.listeners?.stdout) {
+            opts.listeners.stdout(
+              Buffer.from(
+                "No changes. Your infrastructure matches the configuration.",
+              ),
+            );
+          }
+          return Promise.resolve(0);
+        },
+      );
 
       const runDiff = new RunDiff();
       const result = await runDiff.runDiff();
@@ -358,22 +545,57 @@ describe("RunDiff", () => {
       expect(calledArgs[1]).not.toContain("cdktf diff");
       expect(result).toEqual({
         result_code: "0",
-        summary: "No changes. Your infrastructure matches the configuration."
+        summary: "No changes. Your infrastructure matches the configuration.",
       });
     });
 
+    it("should strip ANSI escape codes from output before parsing", async () => {
+      const ansiNoChanges =
+        "\x1B[32mNo changes. Your infrastructure matches the configuration.\x1B[0m";
+      (exec.exec as jest.Mock).mockImplementation(
+        (
+          _cmd: string,
+          _args: string[],
+          opts?: { listeners?: { stdout?: (data: Buffer) => void } },
+        ) => {
+          if (opts?.listeners?.stdout) {
+            opts.listeners.stdout(Buffer.from(ansiNoChanges));
+          }
+          return Promise.resolve(0);
+        },
+      );
+
+      const runDiff = new RunDiff();
+      const result = await runDiff.runDiff();
+
+      expect(result).toEqual({
+        result_code: "0",
+        summary: "No changes. Your infrastructure matches the configuration.",
+      });
+    });
 
     it("should capture both stdout and stderr output", async () => {
       // Mock exec to simulate output to both streams
-      (exec.exec as jest.Mock).mockImplementation((_cmd: string, _args: string[], opts?: { listeners?: { stdout?: (data: Buffer) => void; stderr?: (data: Buffer) => void } }) => {
-        if (opts?.listeners?.stdout) {
-          opts.listeners.stdout(Buffer.from("Plan: 1 to add"));
-        }
-        if (opts?.listeners?.stderr) {
-          opts.listeners.stderr(Buffer.from(", 0 to change, 0 to destroy."));
-        }
-        return Promise.resolve(0);
-      });
+      (exec.exec as jest.Mock).mockImplementation(
+        (
+          _cmd: string,
+          _args: string[],
+          opts?: {
+            listeners?: {
+              stdout?: (data: Buffer) => void;
+              stderr?: (data: Buffer) => void;
+            };
+          },
+        ) => {
+          if (opts?.listeners?.stdout) {
+            opts.listeners.stdout(Buffer.from("Plan: 1 to add"));
+          }
+          if (opts?.listeners?.stderr) {
+            opts.listeners.stderr(Buffer.from(", 0 to change, 0 to destroy."));
+          }
+          return Promise.resolve(0);
+        },
+      );
 
       const runDiff = new RunDiff();
       const result = await runDiff.runDiff();
@@ -381,7 +603,7 @@ describe("RunDiff", () => {
       // Verify combined output is processed correctly
       expect(result).toEqual({
         result_code: "2",
-        summary: "Plan: 1 to add, 0 to change, 0 to destroy."
+        summary: "Plan: 1 to add, 0 to change, 0 to destroy.",
       });
     });
   });
@@ -391,25 +613,41 @@ describe("RunDiff", () => {
       // Mock responses with error result
       const mockJobInfo = {
         job_id: 12345,
-        html_url: "https://github.com/test-owner/test-repo/actions/runs/12345"
+        html_url: "https://github.com/test-owner/test-repo/actions/runs/12345",
       };
-      jest.spyOn(RunDiff.prototype, "getJobInformation").mockResolvedValue(mockJobInfo);
+      jest
+        .spyOn(RunDiff.prototype, "getJobInformation")
+        .mockResolvedValue(mockJobInfo);
 
       const errorSummary = "Error: Invalid configuration";
       const mockDiffResult = {
         result_code: "1" as const,
-        summary: errorSummary
+        summary: errorSummary,
       };
-      jest.spyOn(RunDiff.prototype, "runDiff").mockResolvedValue(mockDiffResult);
+      jest
+        .spyOn(RunDiff.prototype, "runDiff")
+        .mockResolvedValue(mockDiffResult);
 
       const runDiff = new RunDiff();
       await runDiff.run();
 
       // Verify outputs were set
-      expect(core.setOutput).toHaveBeenCalledWith("job_id", mockJobInfo.job_id.toString());
-      expect(core.setOutput).toHaveBeenCalledWith("html_url", mockJobInfo.html_url);
-      expect(core.setOutput).toHaveBeenCalledWith("result_code", mockDiffResult.result_code);
-      expect(core.setOutput).toHaveBeenCalledWith("summary", mockDiffResult.summary);
+      expect(core.setOutput).toHaveBeenCalledWith(
+        "job_id",
+        mockJobInfo.job_id.toString(),
+      );
+      expect(core.setOutput).toHaveBeenCalledWith(
+        "html_url",
+        mockJobInfo.html_url,
+      );
+      expect(core.setOutput).toHaveBeenCalledWith(
+        "result_code",
+        mockDiffResult.result_code,
+      );
+      expect(core.setOutput).toHaveBeenCalledWith(
+        "summary",
+        mockDiffResult.summary,
+      );
       expect(core.setOutput).toHaveBeenCalledWith("stack", mockInputs.stack);
 
       // Verify job was failed with error summary
@@ -420,25 +658,77 @@ describe("RunDiff", () => {
       // Mock successful responses
       const mockJobInfo = {
         job_id: 12345,
-        html_url: "https://github.com/test-owner/test-repo/actions/runs/12345"
+        html_url: "https://github.com/test-owner/test-repo/actions/runs/12345",
       };
-      jest.spyOn(RunDiff.prototype, "getJobInformation").mockResolvedValue(mockJobInfo);
+      jest
+        .spyOn(RunDiff.prototype, "getJobInformation")
+        .mockResolvedValue(mockJobInfo);
 
       const mockDiffResult = {
         result_code: "2" as const,
-        summary: "Plan: 1 to add, 0 to change, 0 to destroy."
+        summary: "Plan: 1 to add, 0 to change, 0 to destroy.",
       };
-      jest.spyOn(RunDiff.prototype, "runDiff").mockResolvedValue(mockDiffResult);
+      jest
+        .spyOn(RunDiff.prototype, "runDiff")
+        .mockResolvedValue(mockDiffResult);
 
       const runDiff = new RunDiff();
       await runDiff.run();
 
       // Verify outputs were set correctly
-      expect(core.setOutput).toHaveBeenCalledWith("job_id", mockJobInfo.job_id.toString());
-      expect(core.setOutput).toHaveBeenCalledWith("html_url", mockJobInfo.html_url);
-      expect(core.setOutput).toHaveBeenCalledWith("result_code", mockDiffResult.result_code);
-      expect(core.setOutput).toHaveBeenCalledWith("summary", mockDiffResult.summary);
+      expect(core.setOutput).toHaveBeenCalledWith(
+        "job_id",
+        mockJobInfo.job_id.toString(),
+      );
+      expect(core.setOutput).toHaveBeenCalledWith(
+        "html_url",
+        mockJobInfo.html_url,
+      );
+      expect(core.setOutput).toHaveBeenCalledWith(
+        "result_code",
+        mockDiffResult.result_code,
+      );
+      expect(core.setOutput).toHaveBeenCalledWith(
+        "summary",
+        mockDiffResult.summary,
+      );
       expect(core.setOutput).toHaveBeenCalledWith("stack", mockInputs.stack);
+
+      // Verify output file was written with correct path and JSON content
+      const expectedPath = path.join(
+        mockInputs.working_directory,
+        mockInputs.output_filename,
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expectedPath,
+        JSON.stringify({
+          html_url: mockJobInfo.html_url,
+          job_id: mockJobInfo.job_id.toString(),
+          result_code: mockDiffResult.result_code,
+          stack: mockInputs.stack,
+          summary: mockDiffResult.summary,
+        }),
+      );
+    });
+
+    it("should not call setFailed when result_code is 0 or 2", async () => {
+      const mockJobInfo = {
+        job_id: 12345,
+        html_url: "https://example.com/job",
+      };
+      jest
+        .spyOn(RunDiff.prototype, "getJobInformation")
+        .mockResolvedValue(mockJobInfo);
+      jest.spyOn(RunDiff.prototype, "runDiff").mockResolvedValue({
+        result_code: "0",
+        summary: "No changes. Your infrastructure matches the configuration.",
+      });
+
+      const runDiff = new RunDiff();
+      await runDiff.run();
+
+      expect(core.setFailed).not.toHaveBeenCalled();
     });
   });
-}); 
+});

--- a/__tests__/runDiff.test.ts
+++ b/__tests__/runDiff.test.ts
@@ -9,7 +9,7 @@ import * as path from "path";
 // Mock fs.writeFileSync so we can assert on it without touching disk; keep rest of fs for cleanup
 jest.mock("fs", () => ({
   ...jest.requireActual<typeof import("fs")>("fs"),
-  writeFileSync: jest.fn(),
+  writeFileSync: jest.fn()
 }));
 
 // Mock all external dependencies
@@ -18,7 +18,7 @@ jest.mock("@actions/core", () => ({
   getBooleanInput: jest.fn(),
   setOutput: jest.fn(),
   setFailed: jest.fn(),
-  debug: jest.fn(),
+  debug: jest.fn()
 }));
 
 jest.mock("@actions/github");
@@ -35,7 +35,7 @@ describe("RunDiff", () => {
     stack: "test-stack",
     terraform_version: "1.8.0",
     working_directory: "./",
-    skip_synth: "false",
+    skip_synth: "false"
   };
 
   beforeEach(() => {
@@ -43,16 +43,16 @@ describe("RunDiff", () => {
 
     // `Setup` core.getInput mock
     (core.getInput as jest.Mock).mockImplementation(
-      (name: string) => mockInputs[name as keyof typeof mockInputs],
+      (name: string) => mockInputs[name as keyof typeof mockInputs]
     );
     (core.getBooleanInput as jest.Mock).mockImplementation(
-      (name: string) => mockInputs[name as keyof typeof mockInputs] === "true",
+      (name: string) => mockInputs[name as keyof typeof mockInputs] === "true"
     );
 
     // Setup github.context
     (github.context as unknown) = {
       repo: { owner: "test-owner", repo: "test-repo" },
-      runId: 12345,
+      runId: 12345
     };
   });
 
@@ -60,7 +60,7 @@ describe("RunDiff", () => {
   afterAll(() => {
     const outputPath = path.join(
       mockInputs.working_directory,
-      mockInputs.output_filename,
+      mockInputs.output_filename
     );
     try {
       fs.unlinkSync(outputPath);
@@ -81,7 +81,7 @@ describe("RunDiff", () => {
         status: "completed",
         conclusion: "success",
         started_at: faker.date.recent().toISOString(),
-        completed_at: faker.date.recent().toISOString(),
+        completed_at: faker.date.recent().toISOString()
       };
 
       // Create mock paginated response
@@ -95,9 +95,9 @@ describe("RunDiff", () => {
             status: "completed",
             conclusion: "success",
             started_at: faker.date.recent().toISOString(),
-            completed_at: faker.date.recent().toISOString(),
+            completed_at: faker.date.recent().toISOString()
           })),
-        targetJob,
+        targetJob
       ];
 
       // Mock Octokit paginate to return all jobs
@@ -107,9 +107,9 @@ describe("RunDiff", () => {
         paginate: mockPaginate,
         rest: {
           actions: {
-            listJobsForWorkflowRun: jest.fn(),
-          },
-        },
+            listJobsForWorkflowRun: jest.fn()
+          }
+        }
       });
 
       const runDiff = new RunDiff();
@@ -118,7 +118,7 @@ describe("RunDiff", () => {
       // Verify the correct job was found
       expect(result).toEqual({
         job_id: targetJob.id,
-        html_url: targetJob.html_url,
+        html_url: targetJob.html_url
       });
 
       // Verify paginate was called correctly
@@ -126,7 +126,7 @@ describe("RunDiff", () => {
       expect(mockPaginate).toHaveBeenCalledWith(expect.any(Function), {
         owner: "test-owner",
         repo: "test-repo",
-        run_id: 12345,
+        run_id: 12345
       });
     });
 
@@ -138,9 +138,9 @@ describe("RunDiff", () => {
         paginate: mockPaginate,
         rest: {
           actions: {
-            listJobsForWorkflowRun: jest.fn(),
-          },
-        },
+            listJobsForWorkflowRun: jest.fn()
+          }
+        }
       });
 
       const runDiff = new RunDiff();
@@ -163,7 +163,7 @@ describe("RunDiff", () => {
           status: "completed",
           conclusion: "success",
           started_at: faker.date.recent().toISOString(),
-          completed_at: faker.date.recent().toISOString(),
+          completed_at: faker.date.recent().toISOString()
         }));
 
       // Mock Octokit to return a single page with no matching job
@@ -173,16 +173,16 @@ describe("RunDiff", () => {
         paginate: mockPaginate,
         rest: {
           actions: {
-            listJobsForWorkflowRun: jest.fn(),
-          },
-        },
+            listJobsForWorkflowRun: jest.fn()
+          }
+        }
       });
 
       const runDiff = new RunDiff();
 
       // Verify that getJobInformation throws with the correct error message
       await expect(runDiff.getJobInformation()).rejects.toThrow(
-        `Could not find job with name ${mockInputs.job_name}`,
+        `Could not find job with name ${mockInputs.job_name}`
       );
 
       // Verify paginate was called correctly
@@ -190,7 +190,7 @@ describe("RunDiff", () => {
       expect(mockPaginate).toHaveBeenCalledWith(expect.any(Function), {
         owner: "test-owner",
         repo: "test-repo",
-        run_id: 12345,
+        run_id: 12345
       });
     });
 
@@ -202,7 +202,7 @@ describe("RunDiff", () => {
         status: "completed",
         conclusion: "success",
         started_at: faker.date.recent().toISOString(),
-        completed_at: faker.date.recent().toISOString(),
+        completed_at: faker.date.recent().toISOString()
       };
 
       const mockPaginate = jest.fn().mockResolvedValue([jobWithoutUrl]);
@@ -211,9 +211,9 @@ describe("RunDiff", () => {
         paginate: mockPaginate,
         rest: {
           actions: {
-            listJobsForWorkflowRun: jest.fn(),
-          },
-        },
+            listJobsForWorkflowRun: jest.fn()
+          }
+        }
       });
 
       const runDiff = new RunDiff();
@@ -221,7 +221,7 @@ describe("RunDiff", () => {
 
       expect(result).toEqual({
         job_id: 99999,
-        html_url: "",
+        html_url: ""
       });
     });
   });
@@ -233,17 +233,17 @@ describe("RunDiff", () => {
         (
           _cmd: string,
           _args: string[],
-          opts?: { listeners?: { stdout?: (data: Buffer) => void } },
+          opts?: { listeners?: { stdout?: (data: Buffer) => void } }
         ) => {
           if (opts?.listeners?.stdout) {
             opts.listeners.stdout(
               Buffer.from(
-                "Planning failed. Terraform encountered an error while generating this plan.\nError: Invalid configuration",
-              ),
+                "Planning failed. Terraform encountered an error while generating this plan.\nError: Invalid configuration"
+              )
             );
           }
           return Promise.resolve(1);
-        },
+        }
       );
 
       const runDiff = new RunDiff();
@@ -252,14 +252,14 @@ describe("RunDiff", () => {
       // Verify the error is handled correctly (generic non-zero exit message)
       expect(result).toEqual({
         result_code: "1",
-        summary: "Plan failed with exit code 1. See run for details.",
+        summary: "Plan failed with exit code 1. See run for details."
       });
 
       // Verify exec was called with correct command
       expect(exec.exec).toHaveBeenCalledWith(
         "bash",
         ["-c", `CI=1 npx cdktf diff ${mockInputs.stack}`],
-        expect.any(Object),
+        expect.any(Object)
       );
     });
 
@@ -268,17 +268,17 @@ describe("RunDiff", () => {
         (
           _cmd: string,
           _args: string[],
-          opts?: { listeners?: { stdout?: (data: Buffer) => void } },
+          opts?: { listeners?: { stdout?: (data: Buffer) => void } }
         ) => {
           if (opts?.listeners?.stdout) {
             opts.listeners.stdout(
               Buffer.from(
-                "Error: ProvisionedThroughputExceededException: The level of configured provisioned throughput for the table was exceeded.",
-              ),
+                "Error: ProvisionedThroughputExceededException: The level of configured provisioned throughput for the table was exceeded."
+              )
             );
           }
           return Promise.resolve(1);
-        },
+        }
       );
 
       const runDiff = new RunDiff();
@@ -287,7 +287,7 @@ describe("RunDiff", () => {
       expect(result).toEqual({
         result_code: "1",
         summary:
-          "DynamoDB is throttling state lock requests. See run for details.",
+          "DynamoDB is throttling state lock requests. See run for details."
       });
     });
 
@@ -296,17 +296,17 @@ describe("RunDiff", () => {
         (
           _cmd: string,
           _args: string[],
-          opts?: { listeners?: { stdout?: (data: Buffer) => void } },
+          opts?: { listeners?: { stdout?: (data: Buffer) => void } }
         ) => {
           if (opts?.listeners?.stdout) {
             opts.listeners.stdout(
               Buffer.from(
-                "Error acquiring the state lock. Another process is holding the lock.",
-              ),
+                "Error acquiring the state lock. Another process is holding the lock."
+              )
             );
           }
           return Promise.resolve(1);
-        },
+        }
       );
 
       const runDiff = new RunDiff();
@@ -314,13 +314,13 @@ describe("RunDiff", () => {
 
       expect(result).toEqual({
         result_code: "1",
-        summary: "Error acquiring the state lock. See run for details.",
+        summary: "Error acquiring the state lock. See run for details."
       });
     });
 
     it("should return error when exec throws", async () => {
       (exec.exec as jest.Mock).mockRejectedValue(
-        new Error("Exec failed: command not found"),
+        new Error("Exec failed: command not found")
       );
 
       const runDiff = new RunDiff();
@@ -328,7 +328,7 @@ describe("RunDiff", () => {
 
       expect(result).toEqual({
         result_code: "1",
-        summary: "Exec failed: command not found",
+        summary: "Exec failed: command not found"
       });
     });
 
@@ -338,17 +338,17 @@ describe("RunDiff", () => {
         (
           _cmd: string,
           _args: string[],
-          opts?: { listeners?: { stdout?: (data: Buffer) => void } },
+          opts?: { listeners?: { stdout?: (data: Buffer) => void } }
         ) => {
           if (opts?.listeners?.stdout) {
             opts.listeners.stdout(
               Buffer.from(
-                "No changes. Your infrastructure matches the configuration.",
-              ),
+                "No changes. Your infrastructure matches the configuration."
+              )
             );
           }
           return Promise.resolve(0);
-        },
+        }
       );
 
       const runDiff = new RunDiff();
@@ -357,14 +357,14 @@ describe("RunDiff", () => {
       // Verify the no changes case is handled correctly
       expect(result).toEqual({
         result_code: "0",
-        summary: "No changes. Your infrastructure matches the configuration.",
+        summary: "No changes. Your infrastructure matches the configuration."
       });
 
       // Verify exec was called with correct command
       expect(exec.exec).toHaveBeenCalledWith(
         "bash",
         ["-c", `CI=1 npx cdktf diff ${mockInputs.stack}`],
-        expect.any(Object),
+        expect.any(Object)
       );
     });
 
@@ -376,13 +376,13 @@ describe("RunDiff", () => {
         (
           _cmd: string,
           _args: string[],
-          opts?: { listeners?: { stdout?: (data: Buffer) => void } },
+          opts?: { listeners?: { stdout?: (data: Buffer) => void } }
         ) => {
           if (opts?.listeners?.stdout) {
             opts.listeners.stdout(Buffer.from(planSummary));
           }
           return Promise.resolve(0);
-        },
+        }
       );
 
       const runDiff = new RunDiff();
@@ -391,14 +391,14 @@ describe("RunDiff", () => {
       // Verify the pending changes case is handled correctly
       expect(result).toEqual({
         result_code: "2",
-        summary: planSummary,
+        summary: planSummary
       });
 
       // Verify exec was called with correct command
       expect(exec.exec).toHaveBeenCalledWith(
         "bash",
         ["-c", `CI=1 npx cdktf diff ${mockInputs.stack}`],
-        expect.any(Object),
+        expect.any(Object)
       );
     });
 
@@ -408,17 +408,17 @@ describe("RunDiff", () => {
         (
           _cmd: string,
           _args: string[],
-          opts?: { listeners?: { stdout?: (data: Buffer) => void } },
+          opts?: { listeners?: { stdout?: (data: Buffer) => void } }
         ) => {
           if (opts?.listeners?.stdout) {
             opts.listeners.stdout(
               Buffer.from(
-                "Some unexpected output that doesn't match any known patterns",
-              ),
+                "Some unexpected output that doesn't match any known patterns"
+              )
             );
           }
           return Promise.resolve(0);
-        },
+        }
       );
 
       const runDiff = new RunDiff();
@@ -427,14 +427,14 @@ describe("RunDiff", () => {
       // Verify the unknown error case is handled correctly
       expect(result).toEqual({
         result_code: "1",
-        summary: "Could not determine if diff ran successfully",
+        summary: "Could not determine if diff ran successfully"
       });
 
       // Verify exec was called with correct command
       expect(exec.exec).toHaveBeenCalledWith(
         "bash",
         ["-c", `CI=1 npx cdktf diff ${mockInputs.stack}`],
-        expect.any(Object),
+        expect.any(Object)
       );
     });
 
@@ -448,17 +448,17 @@ describe("RunDiff", () => {
         (
           _cmd: string,
           _args: string[],
-          opts?: { listeners?: { stdout?: (data: Buffer) => void } },
+          opts?: { listeners?: { stdout?: (data: Buffer) => void } }
         ) => {
           if (opts?.listeners?.stdout) {
             opts.listeners.stdout(
               Buffer.from(
-                "No changes. Your infrastructure matches the configuration.",
-              ),
+                "No changes. Your infrastructure matches the configuration."
+              )
             );
           }
           return Promise.resolve(0);
-        },
+        }
       );
 
       const runDiff = new RunDiff();
@@ -469,7 +469,7 @@ describe("RunDiff", () => {
       expect(exec.exec).toHaveBeenCalledWith(
         "bash",
         ["-c", `CI=1 npx cdktf diff ${mockInputs.stack}`],
-        expect.objectContaining({ cwd: "./" }),
+        expect.objectContaining({ cwd: "./" })
       );
     });
 
@@ -478,7 +478,7 @@ describe("RunDiff", () => {
       (core.getBooleanInput as jest.Mock).mockImplementation((name: string) =>
         name === "skip_synth"
           ? true
-          : mockInputs[name as keyof typeof mockInputs] === "true",
+          : mockInputs[name as keyof typeof mockInputs] === "true"
       );
 
       // Mock exec to simulate no changes output
@@ -486,13 +486,13 @@ describe("RunDiff", () => {
         (
           _cmd: string,
           _args: string[],
-          opts?: { listeners?: { stdout?: (data: Buffer) => void } },
+          opts?: { listeners?: { stdout?: (data: Buffer) => void } }
         ) => {
           if (opts?.listeners?.stdout) {
             opts.listeners.stdout(Buffer.from("No changes"));
           }
           return Promise.resolve(0);
-        },
+        }
       );
 
       const runDiff = new RunDiff();
@@ -502,7 +502,7 @@ describe("RunDiff", () => {
       expect(exec.exec).toHaveBeenCalledWith(
         "bash",
         ["-c", `CI=1 npx cdktf diff --skip-synth ${mockInputs.stack}`],
-        expect.any(Object),
+        expect.any(Object)
       );
     });
 
@@ -514,8 +514,7 @@ describe("RunDiff", () => {
         return mockInputs[name as keyof typeof mockInputs];
       });
       (core.getBooleanInput as jest.Mock).mockImplementation(
-        (name: string) =>
-          mockInputs[name as keyof typeof mockInputs] === "true",
+        (name: string) => mockInputs[name as keyof typeof mockInputs] === "true"
       );
 
       let calledCommand = "";
@@ -527,12 +526,12 @@ describe("RunDiff", () => {
           if (opts?.listeners?.stdout) {
             opts.listeners.stdout(
               Buffer.from(
-                "No changes. Your infrastructure matches the configuration.",
-              ),
+                "No changes. Your infrastructure matches the configuration."
+              )
             );
           }
           return Promise.resolve(0);
-        },
+        }
       );
 
       const runDiff = new RunDiff();
@@ -545,7 +544,7 @@ describe("RunDiff", () => {
       expect(calledArgs[1]).not.toContain("cdktf diff");
       expect(result).toEqual({
         result_code: "0",
-        summary: "No changes. Your infrastructure matches the configuration.",
+        summary: "No changes. Your infrastructure matches the configuration."
       });
     });
 
@@ -556,13 +555,13 @@ describe("RunDiff", () => {
         (
           _cmd: string,
           _args: string[],
-          opts?: { listeners?: { stdout?: (data: Buffer) => void } },
+          opts?: { listeners?: { stdout?: (data: Buffer) => void } }
         ) => {
           if (opts?.listeners?.stdout) {
             opts.listeners.stdout(Buffer.from(ansiNoChanges));
           }
           return Promise.resolve(0);
-        },
+        }
       );
 
       const runDiff = new RunDiff();
@@ -570,7 +569,7 @@ describe("RunDiff", () => {
 
       expect(result).toEqual({
         result_code: "0",
-        summary: "No changes. Your infrastructure matches the configuration.",
+        summary: "No changes. Your infrastructure matches the configuration."
       });
     });
 
@@ -585,7 +584,7 @@ describe("RunDiff", () => {
               stdout?: (data: Buffer) => void;
               stderr?: (data: Buffer) => void;
             };
-          },
+          }
         ) => {
           if (opts?.listeners?.stdout) {
             opts.listeners.stdout(Buffer.from("Plan: 1 to add"));
@@ -594,7 +593,7 @@ describe("RunDiff", () => {
             opts.listeners.stderr(Buffer.from(", 0 to change, 0 to destroy."));
           }
           return Promise.resolve(0);
-        },
+        }
       );
 
       const runDiff = new RunDiff();
@@ -603,7 +602,7 @@ describe("RunDiff", () => {
       // Verify combined output is processed correctly
       expect(result).toEqual({
         result_code: "2",
-        summary: "Plan: 1 to add, 0 to change, 0 to destroy.",
+        summary: "Plan: 1 to add, 0 to change, 0 to destroy."
       });
     });
   });
@@ -613,7 +612,7 @@ describe("RunDiff", () => {
       // Mock responses with error result
       const mockJobInfo = {
         job_id: 12345,
-        html_url: "https://github.com/test-owner/test-repo/actions/runs/12345",
+        html_url: "https://github.com/test-owner/test-repo/actions/runs/12345"
       };
       jest
         .spyOn(RunDiff.prototype, "getJobInformation")
@@ -622,7 +621,7 @@ describe("RunDiff", () => {
       const errorSummary = "Error: Invalid configuration";
       const mockDiffResult = {
         result_code: "1" as const,
-        summary: errorSummary,
+        summary: errorSummary
       };
       jest
         .spyOn(RunDiff.prototype, "runDiff")
@@ -634,19 +633,19 @@ describe("RunDiff", () => {
       // Verify outputs were set
       expect(core.setOutput).toHaveBeenCalledWith(
         "job_id",
-        mockJobInfo.job_id.toString(),
+        mockJobInfo.job_id.toString()
       );
       expect(core.setOutput).toHaveBeenCalledWith(
         "html_url",
-        mockJobInfo.html_url,
+        mockJobInfo.html_url
       );
       expect(core.setOutput).toHaveBeenCalledWith(
         "result_code",
-        mockDiffResult.result_code,
+        mockDiffResult.result_code
       );
       expect(core.setOutput).toHaveBeenCalledWith(
         "summary",
-        mockDiffResult.summary,
+        mockDiffResult.summary
       );
       expect(core.setOutput).toHaveBeenCalledWith("stack", mockInputs.stack);
 
@@ -658,7 +657,7 @@ describe("RunDiff", () => {
       // Mock successful responses
       const mockJobInfo = {
         job_id: 12345,
-        html_url: "https://github.com/test-owner/test-repo/actions/runs/12345",
+        html_url: "https://github.com/test-owner/test-repo/actions/runs/12345"
       };
       jest
         .spyOn(RunDiff.prototype, "getJobInformation")
@@ -666,7 +665,7 @@ describe("RunDiff", () => {
 
       const mockDiffResult = {
         result_code: "2" as const,
-        summary: "Plan: 1 to add, 0 to change, 0 to destroy.",
+        summary: "Plan: 1 to add, 0 to change, 0 to destroy."
       };
       jest
         .spyOn(RunDiff.prototype, "runDiff")
@@ -678,26 +677,26 @@ describe("RunDiff", () => {
       // Verify outputs were set correctly
       expect(core.setOutput).toHaveBeenCalledWith(
         "job_id",
-        mockJobInfo.job_id.toString(),
+        mockJobInfo.job_id.toString()
       );
       expect(core.setOutput).toHaveBeenCalledWith(
         "html_url",
-        mockJobInfo.html_url,
+        mockJobInfo.html_url
       );
       expect(core.setOutput).toHaveBeenCalledWith(
         "result_code",
-        mockDiffResult.result_code,
+        mockDiffResult.result_code
       );
       expect(core.setOutput).toHaveBeenCalledWith(
         "summary",
-        mockDiffResult.summary,
+        mockDiffResult.summary
       );
       expect(core.setOutput).toHaveBeenCalledWith("stack", mockInputs.stack);
 
       // Verify output file was written with correct path and JSON content
       const expectedPath = path.join(
         mockInputs.working_directory,
-        mockInputs.output_filename,
+        mockInputs.output_filename
       );
       expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
       expect(fs.writeFileSync).toHaveBeenCalledWith(
@@ -707,22 +706,22 @@ describe("RunDiff", () => {
           job_id: mockJobInfo.job_id.toString(),
           result_code: mockDiffResult.result_code,
           stack: mockInputs.stack,
-          summary: mockDiffResult.summary,
-        }),
+          summary: mockDiffResult.summary
+        })
       );
     });
 
     it("should not call setFailed when result_code is 0 or 2", async () => {
       const mockJobInfo = {
         job_id: 12345,
-        html_url: "https://example.com/job",
+        html_url: "https://example.com/job"
       };
       jest
         .spyOn(RunDiff.prototype, "getJobInformation")
         .mockResolvedValue(mockJobInfo);
       jest.spyOn(RunDiff.prototype, "runDiff").mockResolvedValue({
         result_code: "0",
-        summary: "No changes. Your infrastructure matches the configuration.",
+        summary: "No changes. Your infrastructure matches the configuration."
       });
 
       const runDiff = new RunDiff();

--- a/action.yml
+++ b/action.yml
@@ -100,6 +100,7 @@ runs:
       run: node ${{ github.action_path }}/dist/index.js
 
     - uses: actions/upload-artifact@v4
+      if: always()
       name: Save Outputs
       with:
         name: ${{ steps.diff_action.outputs.job_id }}

--- a/src/runDiff.ts
+++ b/src/runDiff.ts
@@ -223,20 +223,27 @@ export class RunDiff {
     );
 
     if (exitCode !== 0) {
+      // When we exceed the read/write capacity of the DynamoDB table, we get this error.
+      if (cleanOutput.includes("ProvisionedThroughputExceededException")) {
+        return {
+          result_code: "1",
+          summary:
+            "DynamoDB is throttling state lock requests. See run for details.",
+        };
+      }
+
+      // State already lcked
+      if (cleanOutput.includes("Error acquiring the state lock")) {
+        return {
+          result_code: "1",
+          summary: "Error acquiring the state lock. See run for details.",
+        };
+      }
+
+      // Default
       return {
         result_code: "1",
         summary: `Plan failed with exit code ${exitCode}. See run for details.`,
-      };
-    }
-
-    if (
-      cleanOutput.includes(
-        "No changes. Your infrastructure matches the configuration.",
-      )
-    ) {
-      return {
-        result_code: "0",
-        summary: "No changes. Your infrastructure matches the configuration.",
       };
     }
 

--- a/src/runDiff.ts
+++ b/src/runDiff.ts
@@ -82,7 +82,7 @@ export class RunDiff {
       terraformVersion: core.getInput("terraform_version") || "1.8.0",
       workingDirectory: core.getInput("working_directory") || "./",
       skipSynth: core.getBooleanInput("skip_synth"),
-      artifactName: core.getInput("artifact_name"),
+      artifactName: core.getInput("artifact_name")
     };
 
     // Then create octokit with the token
@@ -108,7 +108,7 @@ export class RunDiff {
       job_id: job_id.toString(),
       result_code,
       stack: this.inputs.stack,
-      summary,
+      summary
     };
 
     // Set action outputs
@@ -119,7 +119,7 @@ export class RunDiff {
     // Write outputs to file
     const outputPath = path.join(
       this.inputs.workingDirectory,
-      this.inputs.outputFilename,
+      this.inputs.outputFilename
     );
     fs.writeFileSync(outputPath, JSON.stringify(outputs));
 
@@ -139,18 +139,18 @@ export class RunDiff {
       this.octokit.rest.actions.listJobsForWorkflowRun,
       {
         ...github.context.repo,
-        run_id: github.context.runId,
-      },
+        run_id: github.context.runId
+      }
     );
 
     const job = octokitPaginatedJobs.find(
-      (j) => j.name === this.inputs.jobName,
+      (j) => j.name === this.inputs.jobName
     );
 
     if (job) {
       return {
         job_id: job.id,
-        html_url: job.html_url || "",
+        html_url: job.html_url || ""
       };
     } else {
       throw new Error(`Could not find job with name ${this.inputs.jobName}`);
@@ -172,7 +172,7 @@ export class RunDiff {
     const diffCommand = [
       this.inputs.stubOutputFile
         ? `cat ${this.inputs.stubOutputFile}`
-        : "CI=1 npx cdktf diff",
+        : "CI=1 npx cdktf diff"
     ];
     if (this.inputs.skipSynth) diffCommand.push("--skip-synth");
     diffCommand.push(this.inputs.stack);
@@ -187,9 +187,9 @@ export class RunDiff {
           },
           stderr: (data: Buffer) => {
             output += data.toString();
-          },
+          }
         },
-        cwd: this.inputs.workingDirectory,
+        cwd: this.inputs.workingDirectory
       });
 
       // Write output to file for parsing
@@ -211,7 +211,7 @@ export class RunDiff {
    */
   private parseOutput(
     output: string,
-    exitCode: number,
+    exitCode: number
   ): {
     result_code: ActionOutputs["result_code"];
     summary: string;
@@ -219,7 +219,7 @@ export class RunDiff {
     // eslint-disable-next-line no-control-regex
     const cleanOutput = output.replace(
       /\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]/g,
-      "",
+      ""
     );
 
     if (exitCode !== 0) {
@@ -228,7 +228,7 @@ export class RunDiff {
         return {
           result_code: "1",
           summary:
-            "DynamoDB is throttling state lock requests. See run for details.",
+            "DynamoDB is throttling state lock requests. See run for details."
         };
       }
 
@@ -236,25 +236,25 @@ export class RunDiff {
       if (cleanOutput.includes("Error acquiring the state lock")) {
         return {
           result_code: "1",
-          summary: "Error acquiring the state lock. See run for details.",
+          summary: "Error acquiring the state lock. See run for details."
         };
       }
 
       // Default
       return {
         result_code: "1",
-        summary: `Plan failed with exit code ${exitCode}. See run for details.`,
+        summary: `Plan failed with exit code ${exitCode}. See run for details.`
       };
     }
 
     if (
       cleanOutput.includes(
-        "No changes. Your infrastructure matches the configuration.",
+        "No changes. Your infrastructure matches the configuration."
       )
     ) {
       return {
         result_code: "0",
-        summary: "No changes. Your infrastructure matches the configuration.",
+        summary: "No changes. Your infrastructure matches the configuration."
       };
     }
 


### PR DESCRIPTION
Closes [snapsheettech.atlassian.net/browse/SRE-2560](https://snapsheettech.atlassian.net/browse/SRE-2560)

## What
Changes the jobs for writing the output/result to always run even if the diff fails and updates logic for determining whether a diff succeeded to prevent the issue when a plan is created, but the underlying diff command fails due to a data lookup failure (this was seen when the serverless DB cluster was not supported by the cdtkf-infra version).

## Why
Previously, if one of the cdktf-diff matrix jobs failed, it would skip the output and no summary would be printed out. This makes it tedious to copy plan links into PRs for review. Additionally, the action would succeed in cases where an actual plan was generated even though the command returned a non-success exit code, which could potentially hide failures from teams in certain scenarios.

## How
- Adds additional output parsing and exit code checks.
- Makes artifact upload run always so failures produce output in the summary.

## Testing
You may run the [cdktf-diff action in vice-backend](https://github.com/bodyshopbidsdotcom/vice-backend/actions/workflows/cdktf_diff_workflow_dispatch.yml) using the workflow from `SRE-2560-fix-cdktf-diff-output` to test.

Example tests:
- [Failure from Serverless DB Dashboard](https://github.com/bodyshopbidsdotcom/vice-backend/actions/runs/22581453725) - verify that `vice-backend-release` actually shows a failure for the `ref` diff.
- [State locked](https://github.com/bodyshopbidsdotcom/vice-backend/actions/runs/22583657764) - verify that `vice-backend-qa8` failed in both diffs. If you'd like to test this, run a locally apply and do not accept the plan - just let it set at the prompt so that the state is locked and run the action.